### PR TITLE
Show the input JSON file in the editor in Shopping List

### DIFF
--- a/bin/validate_one_exercise
+++ b/bin/validate_one_exercise
@@ -25,6 +25,9 @@ tests=$(jq -r '.files.test[0]' "$config")
 solution=$(jq -r '.files.example[0] // .files.exemplar[0]' "$config")
 [[ -f ${solution} ]] || die "Missing solution file for $exercise"
 
+# this is usually empty but might have multiple files in it
+readarray -t editor_files < <(jq -r '.files.editor[]?' "$config")
+
 # hello-world has no skips
 # neither do concept exercises
 if [[ ${exercise} != "hello-world" ]] && ! [[ $PWD =~ exercises/concept/ ]]; then
@@ -45,7 +48,7 @@ trap cleanup EXIT
 dir=$(mktemp -d)
 cp "${solution}" "${dir}/${stub}"
 cp "${tests}" "${dir}/${tests}"
-cp bats-extra.bash "${dir}"
+cp bats-extra.bash "${editor_files[@]}" "${dir}"
 
 # Run the tests
 cd "${dir}"

--- a/exercises/concept/shopping/.meta/config.json
+++ b/exercises/concept/shopping/.meta/config.json
@@ -3,7 +3,8 @@
   "files": {
     "solution": ["shopping.jq"],
     "test": ["test-shopping.bats"],
-    "exemplar": [".meta/exemplar.jq"]
+    "exemplar": [".meta/exemplar.jq"],
+    "editor": ["shopping-list.json"]
   },
   "blurb": "jq fundamentals"
 }

--- a/exercises/concept/shopping/shopping-list.json
+++ b/exercises/concept/shopping/shopping-list.json
@@ -1,0 +1,87 @@
+{
+  "name": "Ingredients for pancakes",
+  "ingredients": [
+    {
+      "item": "flour",
+      "amount": {
+        "quantity": 1,
+        "unit": "cup"
+      }
+    },
+    {
+      "item": "sugar",
+      "amount": {
+        "quantity": 0.25,
+        "unit": "cup"
+      }
+    },
+    {
+      "item": "baking powder",
+      "amount": {
+        "quantity": 1,
+        "unit": "teaspoon"
+      }
+    },
+    {
+      "item": "baking soda",
+      "amount": {
+        "quantity": 0.25,
+        "unit": "teaspoon"
+      }
+    },
+    {
+      "item": "salt",
+      "amount": {
+        "quantity": 1,
+        "unit": "pinch"
+      }
+    },
+    {
+      "item": "buttermilk",
+      "amount": {
+        "quantity": 1,
+        "unit": "cup"
+      },
+      "substitute": "regular milk"
+    },
+    {
+      "item": "eggs",
+      "amount": {
+        "quantity": 1,
+        "unit": "egg"
+      }
+    },
+    {
+      "item": "melted butter",
+      "amount": {
+        "quantity": 1,
+        "unit": "tablespoon"
+      },
+      "substitute": "vegetable oil"
+    }
+  ],
+  "optional ingredients": [
+    {
+      "item": "cinnamon",
+      "amount": {
+        "quantity": 0.25,
+        "unit": "teaspoon"
+      }
+    },
+    {
+      "item": "vanilla extract",
+      "amount": {
+        "quantity": 0.5,
+        "unit": "teaspoon"
+      }
+    },
+    {
+      "item": "blueberries",
+      "amount": {
+        "quantity": 0.25,
+        "unit": "cup"
+      },
+      "substitute": "chopped apple"
+    }
+  ]
+}

--- a/exercises/concept/shopping/test-shopping.bats
+++ b/exercises/concept/shopping/test-shopping.bats
@@ -1,127 +1,30 @@
 #!/usr/bin/env bats
 load bats-extra
 
-setup() {
-    cat > input.json <<'END_JSON'
-{
-  "name": "Ingredients for pancakes",
-  "ingredients": [
-    {
-      "item": "flour",
-      "amount": {
-        "quantity": 1,
-        "unit": "cup"
-      }
-    },
-    {
-      "item": "sugar",
-      "amount": {
-        "quantity": 0.25,
-        "unit": "cup"
-      }
-    },
-    {
-      "item": "baking powder",
-      "amount": {
-        "quantity": 1,
-        "unit": "teaspoon"
-      }
-    },
-    {
-      "item": "baking soda",
-      "amount": {
-        "quantity": 0.25,
-        "unit": "teaspoon"
-      }
-    },
-    {
-      "item": "salt",
-      "amount": {
-        "quantity": 1,
-        "unit": "pinch"
-      }
-    },
-    {
-      "item": "buttermilk",
-      "amount": {
-        "quantity": 1,
-        "unit": "cup"
-      },
-      "substitute": "regular milk"
-    },
-    {
-      "item": "eggs",
-      "amount": {
-        "quantity": 1,
-        "unit": "egg"
-      }
-    },
-    {
-      "item": "melted butter",
-      "amount": {
-        "quantity": 1,
-        "unit": "tablespoon"
-      },
-      "substitute": "vegetable oil"
-    }
-  ],
-  "optional ingredients": [
-    {
-      "item": "cinnamon",
-      "amount": {
-        "quantity": 0.25,
-        "unit": "teaspoon"
-      }
-    },
-    {
-      "item": "vanilla extract",
-      "amount": {
-        "quantity": 0.5,
-        "unit": "teaspoon"
-      }
-    },
-    {
-      "item": "blueberries",
-      "amount": {
-        "quantity": 0.25,
-        "unit": "cup"
-      },
-      "substitute": "chopped apple"
-    }
-  ]
-}
-END_JSON
-
-}
-
-teardown() {
-    rm input.json
-}
-
 @test "Show shopping list name" {
     ## task 1
-    run jq -f shopping.jq input.json
+    run jq -f shopping.jq shopping-list.json
     assert_success
     assert_line --index 0 '"Ingredients for pancakes"'
 }
 
 @test "Count the ingredients" {
     ## task 2
-    run jq -f shopping.jq input.json
+    run jq -f shopping.jq shopping-list.json
     assert_success
     assert_line --index 1 '8'
 }
 
 @test "Show how much sugar is needed" {
     ## task 3
-    run jq -f shopping.jq input.json
+    run jq -f shopping.jq shopping-list.json
     assert_success
     assert_line --index 2 '0.25'
 }
 
 @test "Map of substitutions" {
     ## task 4
-    run jq -c -f shopping.jq input.json
+    run jq -c -f shopping.jq shopping-list.json
     assert_success
     assert_line --index 3 '{"buttermilk":"regular milk","melted butter":"vegetable oil","blueberries":"chopped apple"}'
 }


### PR DESCRIPTION
The "editor files" are supposed to be visible in the editor but readonly. This required an improvement to the validate_one_exercise script to pull these files into the temp directory.

This addresses point 3 in #72 