### PR TITLE
More explanation about commas in function arguments

### DIFF
--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -1,6 +1,6 @@
 # About
 
-JSON defines an array as:
+JSON defines an **array** as:
 
 > An array is an ordered collection of values.
 > An array begins with `[` left bracket and ends with `]` right bracket.
@@ -36,7 +36,7 @@ Retrieve an element from an array with a bracket expression:
 Negative indexes count backwards from the end of the array:
 `.[-1]` gets the last element; `.[-2]` is the second last.
 
-A "slice" is a sub-sequence of the array.
+A **slice** is a sub-sequence of the array.
 `.[10:15]` returns 5 elements starting from index 10; the end index is _not included_.
 
 There are some convenience functions:

--- a/concepts/arrays/introduction.md
+++ b/concepts/arrays/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-JSON defines an array as:
+JSON defines an **array** as:
 
 > An array is an ordered collection of values.
 > An array begins with `[` left bracket and ends with `]` right bracket.
@@ -36,7 +36,7 @@ Retrieve an element from an array with a bracket expression:
 Negative indexes count backwards from the end of the array:
 `.[-1]` gets the last element; `.[-2]` is the second last.
 
-A "slice" is a sub-sequence of the array.
+A **slice** is a sub-sequence of the array.
 `.[10:15]` returns 5 elements starting from index 10; the end index is _not included_.
 
 There are some convenience functions:

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -30,14 +30,14 @@ See [the manual][man-cli] for details about all the options.
 
 ## Filters and Pipes
 
-Filters are also known as Expressions.
+**Filters** are also known as **Expressions**.
 
-A filter takes an input and produces an output.
-Like the way you work in a unix shell, you can join filters with a pipe `|` to connect the output of one filter to the input of another.
+A _filter_ takes an input and produces an output.
+Like the way you work in a unix shell, you can join _filters_ with a pipe `|` to connect the output of one _filter_ to the input of another.
 
 ## The Identity Filter: `.`
 
-This is the simplest filter.
+This is the simplest _filter_.
 It simply passes its input to its output.
 For example, `jq` pretty-prints by default, so passing JSON the `.` filter gives nicely formatted output for free!
 
@@ -52,17 +52,17 @@ $ echo '[1, 2, 3]' | jq '.'
 
 ## Arrays
 
-This will be quick introduction to working with arrays.
+This will be quick introduction to working with **arrays**.
 We will cover this topic in greater detail later.
 
-Array elements are accessed with brackets, and are zero-indexed.
+_Array_ elements are accessed with brackets, and are zero-indexed.
 
 ```sh
 $ echo '[10, 20, 30]' | jq '.[1]'
 20
 ```
 
-A filter can build an array by wrapping an expression in `[` and `]`
+A _filter_ can build an _array_ by wrapping an expression in `[` and `]`
 
 - with a known list of elements:
 
@@ -90,26 +90,26 @@ A filter can build an array by wrapping an expression in `[` and `]`
 
 ## Comma is an operator
 
-The comma is not just syntax that separates array elements.
-Comma is an **operator** that joins streams.
+The _comma_ is not just syntax that separates _array_ elements.
+**Comma** is an **operator** that joins streams.
 
-For example `[1, 2, 3]` is a filter that uses the array constructor `[]` to collect the result of joining the three expressions `1`, `2` and `3`.
+For example `[1, 2, 3]` is a _filter_ that uses the _arraya_ constructor `[]` to collect the result of joining the three expressions `1`, `2` and `3`.
 
 Did you notice the semi-colons in `range(10; 70; 15)` above?
-Because commas have a specific purpose in the `jq` language, functions that take multiple arguments use semi-colons to separate the arguments.
+Because _commas_ have a specific purpose in the `jq` language, functions that take multiple arguments use semi-colons to separate the arguments.
 
 ## Objects
 
-A quick introduction to objects.
+A quick introduction to **objects**.
 
-Similar to many programming languages, use dots to access object properties
+Similar to many programming languages, use dots to access _object_ properties
 
 ```sh
 $ echo '{"foo": {"bar": "qux"}}' | jq '.foo.bar'
 "qux"
 ```
 
-Brackets can be used for objects too, but then quotes are needed for string literals.
+Brackets can be used for _objects_ too, but then quotes are needed for string literals.
 This is one method to work with keys containing spaces.
 
 ```sh
@@ -117,8 +117,8 @@ $ echo '{"foo bar": "qux"}' | jq '.["foo bar"]'
 "qux"
 ```
 
-You can construct an object with `{}` and `key: value` pairs.
-Quotes are not required around keys that are "simple" strings.
+You can construct an _object_ with `{}` and `key: value` pairs.
+Quotes are not required around _keys_ that are "simple" strings.
 
 ```sh
 jq -n '{question: 6 * 9, answer: 42}'
@@ -133,7 +133,7 @@ outputs
 }
 ```
 
-To treat the key as an expression, you must wrap it in parentheses
+To treat the _key_ as an _expression_, you must wrap it in parentheses
 
 ```sh
 echo '[["question", "answer"], [54, 42]]' \
@@ -167,7 +167,7 @@ But this is so common, there is shorthand syntax for it:
 
 ## Pipelines
 
-For example, given "file.json" containing
+For example, given `file.json` containing
 
 ```json
 {
@@ -176,7 +176,7 @@ For example, given "file.json" containing
 }
 ```
 
-Let's calculate the length of the key2 array:
+Let's calculate the length of the key2 _array_:
 
 ```sh
 $ jq '.key2 | length' file.json
@@ -204,8 +204,8 @@ $ echo '{"answer": 42}' | jq '6 * 9'
 
 ## Filters can output streams of data
 
-A filter can output more than one value.
-For example, the `.[]` filter outputs each element of an array as a separate value:
+A _filter_ can output more than one value.
+For example, the `.[]` _filter_ outputs each element of an _array_ as a separate value:
 
 ```sh
 $ jq -n -c '[1, 2, 3]'
@@ -217,7 +217,7 @@ $ jq -n -c '[1, 2, 3] | .[]'
 3
 ```
 
-Piping such a filter into another will execute the 2nd filter **_for each value_**:
+Piping such a _filter_ into another will execute the 2nd _filter_ **_for each value_**:
 
 ```sh
 $ jq -n -c '[1, 2, 3] | .[] | . * 2'
@@ -227,16 +227,16 @@ $ jq -n -c '[1, 2, 3] | .[] | . * 2'
 ```
 
 This is like implicit iteration.
-Once you understand this technique, you'll realize very powerful jq filters can be very concise.
+Once you understand this technique, you'll realize very powerful `jq` _filters_ can be very concise.
 
 ## Parentheses
 
-Parentheses are used to group sub-expressions together to enforce the order of operations, just like in other languages.
+**Parentheses** are used to group sub-expressions together to enforce the order of operations, just like in other languages.
 In `jq`, the need for them can appear to be somewhat surprising.
 
-For example, let's say we want to construct an array with 2 elements: the square root of 9; and _e_ raised to the power 1.
+For example, let's say we want to construct an _array_ with 2 elements: the square root of 9; and _e_ raised to the power 1.
 The two individual expressions are `9 | sqrt` and `1 | exp`.
-We expect the output to be the array `[3, 2.7...]`
+We expect the output to be the _array_ `[3, 2.7...]`
 
 ```jq
 $ jq -n '[ 9|sqrt, 1|exp ]'
@@ -341,7 +341,7 @@ Without going into great depth (functions will be a topic for another exercise),
 
   Given _some_ input and a filter as an argument:
 
-  - if the filter applied to the argument results in a **true** value, output the input unchanged
+  - if the filter applied to the argument results in a _true_ value, output the input unchanged
   - otherwise, output _nothing_ (not the `null` value, truly no output)
 
   For example, given some numbers, select the ones divisible by 3

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -93,7 +93,7 @@ A _filter_ can build an _array_ by wrapping an expression in `[` and `]`
 The _comma_ is not just syntax that separates _array_ elements.
 **Comma** is an **operator** that joins streams.
 
-For example `[1, 2, 3]` is a _filter_ that uses the _arraya_ constructor `[]` to collect the result of joining the three expressions `1`, `2` and `3`.
+For example `[1, 2, 3]` is a _filter_ that uses the _array_ constructor `[]` to collect the result of joining the three expressions `1`, `2` and `3`.
 
 Did you notice the semi-colons in `range(10; 70; 15)` above?
 Because _commas_ have a specific purpose in the `jq` language, functions that take multiple arguments use semi-colons to separate the arguments.

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -35,14 +35,14 @@ The rest of this lesson will focus on the `jq` _lanaguage_.
 
 ## Filters and Pipes
 
-Filters are also known as Expressions.
+**Filters** are also known as **Expressions**.
 
-A filter takes an input and produces an output.
-Like the way you work in a unix shell, you can join filters with a pipe `|` to connect the output of one filter to the input of another.
+A _filter_ takes an input and produces an output.
+Like the way you work in a unix shell, you can join _filters_ with a pipe `|` to connect the output of one _filter_ to the input of another.
 
 ## The Identity Filter: `.`
 
-This is the simplest filter.
+This is the simplest _filter_.
 It simply passes its input to its output.
 
 ```sh
@@ -56,17 +56,17 @@ $ echo '[1, 2, 3]' | jq '.'
 
 ## Arrays
 
-This will be quick introduction to working with arrays.
+This will be quick introduction to working with **arrays**.
 We will cover this topic in greater detail later.
 
-Array elements are accessed with brackets, and are zero-indexed.
+_Array_ elements are accessed with brackets, and are zero-indexed.
 
 ```sh
 $ echo '[10, 20, 30]' | jq '.[1]'
 20
 ```
 
-A filter can build an array by wrapping an expression in `[` and `]`
+A _filter_ can build an _array_ by wrapping an expression in `[` and `]`
 
 - with a known list of elements:
 
@@ -94,19 +94,19 @@ A filter can build an array by wrapping an expression in `[` and `]`
 
 ## Comma is an operator
 
-The comma is not just syntax that separates array elements.
-Comma is an **operator** that joins streams.
+The _comma_ is not just syntax that separates _array_ elements.
+**Comma** is an **operator** that joins streams.
 
-For example `[1, 2, 3]` is a filter that uses the array constructor `[]` to collect the result of joining the three expressions `1`, `2` and `3`.
+For example `[1, 2, 3]` is a _filter_ that uses the _arraya_ constructor `[]` to collect the result of joining the three expressions `1`, `2` and `3`.
 
 Did you notice the semi-colons in `range(10; 70; 15)` above?
-Because commas have a specific purpose in the `jq` language, functions that take multiple arguments use semi-colons to separate the arguments.
+Because _commas_ have a specific purpose in the `jq` language, functions that take multiple arguments use semi-colons to separate the arguments.
 
 ## Objects
 
-A quick introduction to objects.
+A quick introduction to **objects**.
 
-Similar to many programming languages, use dots to access object properties
+Similar to many programming languages, use dots to access _object_ properties
 
 ```sh
 $ echo '{"foo": {"bar": "qux"}}' | jq '.foo.bar'
@@ -115,7 +115,7 @@ $ echo '{"foo": {"bar": "qux"}}' | jq '.foo.bar'
 
 <!-- prettier-ignore -->
 ~~~~exercism/note
-Brackets can be used for objects too, but then quotes are needed for string literals.
+Brackets can be used for _objects_ too, but then quotes are needed for string literals.
 This is one method to work with keys containing spaces.
 
 ```sh
@@ -126,8 +126,8 @@ $ echo '{"foo bar": "qux"}' | jq '.["foo bar"]'
 
 <!-- prettier-ignore-end -->
 
-You can construct an object with `{}` and `key: value` pairs.
-Quotes are not required around keys that are "simple" strings.
+You can construct an _object_ with `{}` and `key: value` pairs.
+Quotes are not required around _keys_ that are "simple" strings.
 
 ```sh
 jq -n '{question: 6 * 9, answer: 42}'
@@ -142,7 +142,7 @@ outputs
 }
 ```
 
-To treat the key as an _expression_, you must wrap it in parentheses
+To treat the _key_ as an _expression_, you must wrap it in parentheses
 
 ```sh
 echo '[{"key":"question", "value":54}, {"key":"answer", "value":42}]' \
@@ -151,7 +151,7 @@ echo '[{"key":"question", "value":54}, {"key":"answer", "value":42}]' \
 
 ## Pipelines
 
-For example, given "file.json" containing
+For example, given `file.json` containing
 
 ```json
 {
@@ -160,14 +160,14 @@ For example, given "file.json" containing
 }
 ```
 
-Let's calculate the length of the key2 array:
+Let's calculate the length of the key2 _array_:
 
 ```sh
 $ jq '.key2 | length' file.json
 3
 ```
 
-We're _piping_ the output of the `.key2` expression as the input to `length` which unsurprisingly outputs the number of elements in the array.
+We're _piping_ the output of the `.key2` expression as the input to `length` which unsurprisingly outputs the number of elements in the _array_.
 
 ## Filters can ignore their input
 
@@ -180,8 +180,8 @@ $ echo '{"answer": 42}' | jq '6 * 9'
 
 ## Filters can output streams of data
 
-A filter can output more than one value.
-For example, the `.[]` filter outputs each element of an array as a separate value:
+A _filter_ can output more than one value.
+For example, the `.[]` _filter_ outputs each element of an _array_ as a separate value:
 
 ```sh
 $ jq -n -c '[1, 2, 3]'
@@ -193,7 +193,7 @@ $ jq -n -c '[1, 2, 3] | .[]'
 3
 ```
 
-Piping such a filter into another will execute the 2nd filter **_for each value_**:
+Piping such a _filter_ into another will execute the 2nd _filter_ **_for each value_**:
 
 ```sh
 $ jq -n -c '[1, 2, 3] | .[] | . * 2'
@@ -203,16 +203,16 @@ $ jq -n -c '[1, 2, 3] | .[] | . * 2'
 ```
 
 This is like implicit iteration.
-Once you understand this technique, you'll realize very powerful jq filters can be very concise.
+Once you understand this technique, you'll realize very powerful `jq` _filters_ can be very concise.
 
 ## Parentheses
 
-Parentheses are used to group sub-expressions together to enforce the order of operations, just like in other languages.
+**Parentheses** are used to group sub-expressions together to enforce the order of operations, just like in other languages.
 In `jq`, the need for them can appear to be somewhat surprising.
 
-For example, let's say we want to construct an array with 2 elements: the square root of 9; and _e_ raised to the power 1.
+For example, let's say we want to construct an _array_ with 2 elements: the square root of 9; and _e_ raised to the power 1.
 The two individual expressions are `9 | sqrt` and `1 | exp`.
-We expect the output to be the array `[3, 2.7...]`
+We expect the output to be the _array_ `[3, 2.7...]`
 
 ```jq
 $ jq -n '[ 9|sqrt, 1|exp ]'
@@ -291,7 +291,7 @@ Without going into great depth (functions will be a topic for another exercise),
 
   Given _some_ input and a filter as an argument:
 
-  - if the filter applied to the argument results in a **true** value, output the input unchanged
+  - if the filter applied to the argument results in a _true_ value, output the input unchanged
   - otherwise, output _nothing_ (not the `null` value, truly no output)
 
   For example, given some numbers, select the ones divisible by 3

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -97,7 +97,7 @@ A _filter_ can build an _array_ by wrapping an expression in `[` and `]`
 The _comma_ is not just syntax that separates _array_ elements.
 **Comma** is an **operator** that joins streams.
 
-For example `[1, 2, 3]` is a _filter_ that uses the _arraya_ constructor `[]` to collect the result of joining the three expressions `1`, `2` and `3`.
+For example `[1, 2, 3]` is a _filter_ that uses the _array_ constructor `[]` to collect the result of joining the three expressions `1`, `2` and `3`.
 
 Did you notice the semi-colons in `range(10; 70; 15)` above?
 Because _commas_ have a specific purpose in the `jq` language, functions that take multiple arguments use semi-colons to separate the arguments.

--- a/concepts/comparison/about.md
+++ b/concepts/comparison/about.md
@@ -27,7 +27,7 @@ The result of the comparison is always a boolean value, so either `true` or `fal
 
 The comparison operators above can also be used to compare strings.
 In that case, a dictionary (lexicographical) order is applied.
-The ordering is "by unicode codepoint value".
+The ordering is _by unicode codepoint value_.
 
 ```jq
 "Apple" > "Pear",   # => false

--- a/concepts/comparison/about.md
+++ b/concepts/comparison/about.md
@@ -27,7 +27,9 @@ The result of the comparison is always a boolean value, so either `true` or `fal
 
 The comparison operators above can also be used to compare strings.
 In that case, a dictionary (lexicographical) order is applied.
-The ordering is _by unicode codepoint value_.
+The ordering is [by unicode codepoint value][sort].
+
+[sort]: https://stedolan.github.io/jq/manual/v1.6/#sort,sort_by(path_expression)
 
 ```jq
 "Apple" > "Pear",   # => false

--- a/concepts/comparison/introduction.md
+++ b/concepts/comparison/introduction.md
@@ -27,7 +27,7 @@ The result of the comparison is always a boolean value, so either `true` or `fal
 
 The comparison operators above can also be used to compare strings.
 In that case, a dictionary (lexicographical) order is applied.
-The ordering is "by unicode codepoint value".
+The ordering is _by unicode codepoint value_.
 
 ```jq
 "Apple" > "Pear",   # => false

--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -2,9 +2,9 @@
 
 ## If Expression
 
-`jq`'s conditional expression is `if A then B else C end`.
+`jq`'s **conditional expression** is `if A then B else C end`.
 
-`if-then-else` is a filter like all jq builtins: it takes an input and produces an output.
+`if-then-else` is a filter like all `jq` builtins: it takes an input and produces an output.
 
 If the expression `A` produces a "truthy" value, then the `if` filter evaluates `B`.
 Otherwise it evaluates `C`.
@@ -49,7 +49,7 @@ Everything else is "true", even the number zero and the empty string, array and 
 
 ## Boolean Operators
 
-The boolean operators `and` and `or` can be used to build complex queries.
+The **boolean operators** `and` and `or` can be used to build complex queries.
 
 ```jq
 42 | if . < 33 or . > 66 then "big or small"
@@ -67,7 +67,7 @@ To negate, use `not`. This is a **filter** not an operator.
 
 ## Alternative Operator
 
-The alternative operator allows you to specify a "default" value if an expression is false or null.
+The **alternative operator** allows you to specify a "default" value if an expression is false or null.
 
 ```jq
 A // B

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -2,9 +2,9 @@
 
 ## If Expression
 
-`jq`'s conditional expression is `if A then B else C end`.
+`jq`'s **conditional expression** is `if A then B else C end`.
 
-`if-then-else` is a filter like all jq builtins: it takes an input and produces an output.
+`if-then-else` is a filter like all `jq` builtins: it takes an input and produces an output.
 
 If the expression `A` produces a "truthy" value, then the `if` filter evaluates `B`.
 Otherwise it evaluates `C`.
@@ -40,7 +40,7 @@ Everything else is "true", even the number zero and the empty string, array and 
 
 ## Boolean Operators
 
-The boolean operators `and` and `or` can be used to build complex queries.
+The **boolean operators** `and` and `or` can be used to build complex queries.
 
 ```jq
 42 | if . < 33 or . > 66 then "big or small"
@@ -58,7 +58,7 @@ To negate, use `not`. This is a **filter** not an operator.
 
 ## Alternative Operator
 
-The alternative operator allows you to specify a "default" value if an expression is false or null.
+The **alternative operator** allows you to specify a "default" value if an expression is false or null.
 
 ```jq
 A // B

--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -75,16 +75,14 @@ Using a comma instead of a semi-colon will attempt to call a _1-argument_ `add_m
 ```
 
 The comma in `5, 4` concatenates the numbers 5 and 4 into a stream. 
-But giving a stream as a function argument means we want to execute the function _with each element of the stream as an individual argument_.
-We can think of `jq` "factoring out" the comma and processing that filter like this.
+When we call a function with a stream as an argument, `jq` will call that function multiple times, once for each value in the stream. 
+This is an example of the "implicit iteration" inherent in `jq` streams.
+`10 | add_mul(5, 4)` is equivalent to the following.
 
 ```jq
 (10 | add_mul(5)), (10 | add_mul(4))
 ```
-
 Now we can see how the `add_mul/1 is not defined` error pops up.
-
-This is an example of the "implicit iteration" inherent in `jq` streams.
 ~~~~
 
 ### Arguments are _expressions_

--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -55,7 +55,7 @@ A _function_ introduces a new **scope** for variables and nested functons.
 
 ## Arguments
 
-_Function_ arguments are separated by _semi-colons_ not commas.
+_Function_ **arguments** are separated by _semi-colons_ not commas.
 For example, a _function_ that takes a number, and then adds a number and multiplies by a number:
 
 ```jq

--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -87,7 +87,7 @@ Now we can see how the `add_mul/1 is not defined` error pops up.
 
 ### Arguments are _expressions_
 
-**Function arguments** are filters, not values.
+Function _arguments_ are filters, not values.
 In this sense, they act like what other languages describe as callbacks:
 
 Using the `add_mul` function as an example:

--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -73,6 +73,18 @@ Using a comma instead of a semi-colon will attempt to call a _1-argument_ `add_m
 10 | add_mul(5, 4)
 # error: add_mul/1 is not defined
 ```
+
+The comma in `5, 4` concatenates the numbers 5 and 4 into a stream. 
+But giving a stream as a function argument means we want to execute the function _with each element of the stream as an individual argument_.
+We can think of `jq` "factoring out" the comma and processing that filter like this.
+
+```jq
+(10 | add_mul(5)), (10 | add_mul(4))
+```
+
+Now we can see how the `add_mul/1 is not defined` error pops up.
+
+This is an example of the "implicit iteration" inherent in `jq` streams.
 ~~~~
 
 ### Arguments are _expressions_

--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -1,11 +1,11 @@
 # Functions in `jq`
 
-You can define your own custom functions in `jq` to encapsulate whatever logic you need.
-Functions act just like builtins: they take an input and emit zero, one or more outputs.
+You can define your own **custom functions** in `jq` to encapsulate whatever logic you need.
+_Functions_ act just like builtins: they take an input and emit zero, one or more outputs.
 
 ## Defining a function
 
-You can define a `jq` function using the following syntax:
+You can define a `jq` _function_ using the following syntax:
 
 ```jq
 # no arguments
@@ -23,7 +23,7 @@ def funcname(args): expression;
 
 ## Where to put functions
 
-Functions must be defined before they are used: this is an error:
+_Functions_ must be defined before they are used: this is an error:
 
 ```jq
 def A: B(10);
@@ -32,11 +32,11 @@ A
 # => error: B/1 is not defined
 ```
 
-This implies you have to place functions at the top of your jq code, prior to the "main" expression.
+This implies you have to place _functions_ at the top of your `jq` code, prior to the "main" expression.
 
 ### Nested functions
 
-Functions can be nested:
+_Functions_ can be nested:
 
 ```jq
 def A:
@@ -47,16 +47,16 @@ A
 # => 11
 ```
 
-Here, the `B` function is only visible in the body of `A`.
+Here, the `B` _function_ is only visible in the body of `A`.
 
 ## Scope
 
-A function introduces a new scope for variables and nested functons.
+A _function_ introduces a new **scope** for variables and nested functons.
 
 ## Arguments
 
-Function arguments are separated by _semi-colons_ not commas.
-For example, a function that takes a number, and then adds a number and multiplies by a number:
+_Function_ arguments are separated by _semi-colons_ not commas.
+For example, a _function_ that takes a number, and then adds a number and multiplies by a number:
 
 ```jq
 def add_mul(adder; multiplier): (. + adder) * multiplier;
@@ -87,7 +87,7 @@ Now we can see how the `add_mul/1 is not defined` error pops up.
 
 ### Arguments are _expressions_
 
-Function arguments are filters, not values.
+**Function arguments** are filters, not values.
 In this sense, they act like what other languages describe as callbacks:
 
 Using the `add_mul` function as an example:
@@ -107,7 +107,7 @@ What's happening here?
 
 ### Arguments as values
 
-Sometimes you'll want to "materialize" an argument into a variable:
+Sometimes you'll want to "materialize" an _argument_ into a variable:
 
 ```jq
 def my_func(arg):
@@ -124,7 +124,7 @@ def my_func($arg):
 ;
 ```
 
-Take note that this is just "syntactic sugar": the name `arg` with no `$` is still in scope in the function.
+Take note that this is just "syntactic sugar": the name `arg` with no `$` is still in scope in the _function_.
 
 ~~~~exercism/caution
 For example, I wrote something like this to solve an exercise:
@@ -164,9 +164,9 @@ Thus `$this_code` and `$code` were always the same.
 
 ## Arity
 
-Functions have an "arity" -- the number of arguments they take.
+_Functions_ have an **arity** -- the number of _arguments_ they take.
 
-Functions can use the same name with different arities.
+_Functions_ can use the same name with different _arities_.
 The builtin [`range`][man-range] function demonstrates this: `range/1`, `range/2` and `range/3` all co-exist.
 
 This can be useful for defining recursive functions that carry state via arguments.

--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -55,7 +55,7 @@ A _function_ introduces a new **scope** for variables and nested functons.
 
 ## Arguments
 
-_Function_ arguments are separated by _semi-colons_ not commas.
+_Function_ **arguments** are separated by _semi-colons_ not commas.
 For example, a _function_ that takes a number, and then adds a number and multiplies by a number:
 
 ```jq
@@ -77,7 +77,7 @@ Using a comma instead of a semi-colon will attempt to call a _1-argument_ `add_m
 
 ### Arguments are _expressions_
 
-**Function arguments** are filters, not values.
+Function _arguments_ are filters, not values.
 In this sense, they act like what other languages describe as callbacks:
 
 Using the `add_mul` function as an example:

--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -1,11 +1,11 @@
 # Functions in `jq`
 
-You can define your own custom functions in `jq` to encapsulate whatever logic you need.
-Functions act just like builtins: they take an input and emit zero, one or more outputs.
+You can define your own **custom functions** in `jq` to encapsulate whatever logic you need.
+_Functions_ act just like builtins: they take an input and emit zero, one or more outputs.
 
 ## Defining a function
 
-You can define a `jq` function using the following syntax:
+You can define a `jq` _function_ using the following syntax:
 
 ```jq
 # no arguments
@@ -23,7 +23,7 @@ def funcname(args): expression;
 
 ## Where to put functions
 
-Functions must be defined before they are used: this is an error:
+_Functions_ must be defined before they are used: this is an error:
 
 ```jq
 def A: B(10);
@@ -32,11 +32,11 @@ A
 # => error: B/1 is not defined
 ```
 
-This implies you have to place functions at the top of your jq code, prior to the "main" expression.
+This implies you have to place _functions_ at the top of your `jq` code, prior to the "main" expression.
 
 ### Nested functions
 
-Functions can be nested:
+_Functions_ can be nested:
 
 ```jq
 def A:
@@ -47,16 +47,16 @@ A
 # => 11
 ```
 
-Here, the `B` function is only visible in the body of `A`.
+Here, the `B` _function_ is only visible in the body of `A`.
 
 ## Scope
 
-A function introduces a new scope for variables and nested functons.
+A _function_ introduces a new **scope** for variables and nested functons.
 
 ## Arguments
 
-Function arguments are separated by _semi-colons_ not commas.
-For example, a function that takes a number, and then adds a number and multiplies by a number:
+_Function_ arguments are separated by _semi-colons_ not commas.
+For example, a _function_ that takes a number, and then adds a number and multiplies by a number:
 
 ```jq
 def add_mul(adder; multiplier): (. + adder) * multiplier;
@@ -77,7 +77,7 @@ Using a comma instead of a semi-colon will attempt to call a _1-argument_ `add_m
 
 ### Arguments are _expressions_
 
-Function arguments are filters, not values.
+**Function arguments** are filters, not values.
 In this sense, they act like what other languages describe as callbacks:
 
 Using the `add_mul` function as an example:
@@ -97,7 +97,7 @@ What's happening here?
 
 ### Arguments as values
 
-Sometimes you'll want to "materialize" an argument into a variable:
+Sometimes you'll want to "materialize" an _argument_ into a variable:
 
 ```jq
 def my_func(arg):
@@ -114,13 +114,13 @@ def my_func($arg):
 ;
 ```
 
-Take note that this is just "syntactic sugar": the name `arg` with no `$` is still in scope in the function.
+Take note that this is just "syntactic sugar": the name `arg` with no `$` is still in scope in the _function_.
 
 ## Arity
 
-Functions have an "arity" -- the number of arguments they take.
+_Functions_ have an **arity** -- the number of _arguments_ they take.
 
-Functions can use the same name with different arities.
+_Functions_ can use the same name with different _arities_.
 The builtin [`range`][man-range] function demonstrates this: `range/1`, `range/2` and `range/3` all co-exist.
 
 This can be useful for defining recursive functions that carry state via arguments.

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -2,7 +2,7 @@
 
 ## Numbers and numeric operators
 
-All numbers, whether integers or otherwise, are IEEE754 double precision floating point numbers.
+All **numbers**, whether integers or otherwise, are IEEE754 double precision floating point numbers.
 The implementation of `jq` uses the C `double` type.
 This limits us to 53 bits of precision.
 
@@ -62,7 +62,7 @@ This means that `jq` is not capable of handling arbitrarily large numbers.
 
 ## Conditional Expressions
 
-`jq` uses an [`if-then-else` expression][if-then-else] for conditional expressions.
+`jq` uses an [`if-then-else` expression][if-then-else] for **conditional expressions**.
 As an _expression_, it is placed in a pipeline.
 
 Then syntax is: `if CONDTITION then TRUE_EXPR else FALSE_EXPR end`.

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -4,7 +4,7 @@ From [the manual][man-types]
 
 > jq supports the same set of datatypes as JSON - numbers, strings, booleans, arrays, objects (which in JSON-speak are hashes with only string keys), and "null".
 
-Let's focus on *numbers*.
+Let's focus on **numbers**.
 
 ## Numbers and numeric operators
 
@@ -40,7 +40,7 @@ To solve the exercise, you will need to know about conditional expressions.
 
 ### Conditional Expressions
 
-`jq` uses an [`if-then-else` expression][if-then-else] for conditional expressions.
+`jq` uses an [`if-then-else` expression][if-then-else] for **conditional expressions**.
 As an _expression_, it is placed in a pipeline.
 
 Then syntax is: `if CONDITION then TRUE_EXPR else FALSE_EXPR end`.

--- a/concepts/objects/about.md
+++ b/concepts/objects/about.md
@@ -1,8 +1,8 @@
 # About
 
-A JSON object is, to use terminology from other languages, a "hash", "map", or "dictionary".
+A JSON **object** is, to use terminology from other languages, a "hash", "map", or "dictionary".
 
-JSON defines an object as:
+JSON defines an _object_ as:
 
 > An object is an unordered set of **name**/**value** pairs.
 > An object begins with `{` left brace and ends with `}` right brace.
@@ -28,13 +28,13 @@ Note that there **must not** be a comma following the _last_ key-value pair.
 ## Creating objects
 
 Use braces to collect the name/value pairs.
-Even though the names must be strings, they do not need to be quoted if the names are "identifier-like" (composed of alphanumeric characters and underscore, and not started with a digit).
+Even though the names must be strings, they do not need to be quoted if the names are **identifier-like** (composed of alphanumeric characters and underscore, and not started with a digit).
 
 ```jq
 {name: "Jane", age: 42}
 ```
 
-It is valid to use keys that are not "identifier-like".
+It is valid to use keys that are not _identifier-like_.
 Just quote them.
 
 ```jq
@@ -93,13 +93,13 @@ A couple of frequent cases for object construction have short-hand syntax.
 
 ## Indexing
 
-Values are retrieved from an object with _dot notation_.
+Values are retrieved from an object with **dot notation**.
 
 ```jq
 {name: "Jane", age: 42} | .age    # => 42
 ```
 
-If you cannot refer to the key as an identifier, use _bracket notation_.
+If you cannot refer to the key as an identifier, use **bracket notation**.
 
 ```jq
 "name" as $key | {name: "Jane", age: 42} | .$key    # => error
@@ -164,7 +164,7 @@ It returns the updated object.
 ```
 
 The parameter to `del` is an **index expression** (using dot- or bracket-notation) that resolves to a key in the object.
-`jq` calls it a "path expression".
+`jq` calls it a **path expression**.
 It is not sufficient to just give a string.
 
 ```jq

--- a/concepts/objects/introduction.md
+++ b/concepts/objects/introduction.md
@@ -1,8 +1,8 @@
 # Introduction
 
-A JSON object is, to use terminology from other languages, a "hash", "map", or "dictionary".
+A JSON **object** is, to use terminology from other languages, a "hash", "map", or "dictionary".
 
-JSON defines an object as:
+JSON defines an _object_ as:
 
 > An object is an unordered set of **name**/**value** pairs.
 > An object begins with `{` left brace and ends with `}` right brace.
@@ -28,13 +28,13 @@ Note that there **must not** be a comma following the _last_ key-value pair.
 ## Creating objects
 
 Use braces to collect the name/value pairs.
-Even though the names must be strings, they do not need to be quoted if the names are "identifier-like" (composed of alphanumeric characters and underscore, and not started with a digit).
+Even though the names must be strings, they do not need to be quoted if the names are **identifier-like** (composed of alphanumeric characters and underscore, and not started with a digit).
 
 ```jq
 {name: "Jane", age: 42}
 ```
 
-It is valid to use keys that are not "identifier-like".
+It is valid to use keys that are not _identifier-like_.
 Just quote them.
 
 ```jq
@@ -53,13 +53,13 @@ $ echo "Jane" | jq -Rc '{(.): 42}'
 
 ## Indexing
 
-Values are retrieved from an object with _dot notation_.
+Values are retrieved from an object with **dot notation**.
 
 ```jq
 {name: "Jane", age: 42} | .age    # => 42
 ```
 
-If you cannot refer to the key as an identifier, use _bracket notation_.
+If you cannot refer to the key as an identifier, use **bracket notation**.
 
 ```jq
 "name" as $key | {name: "Jane", age: 42} | .$key    # => error
@@ -99,7 +99,7 @@ It returns the updated object.
 ```
 
 The parameter to `del` is an **index expression** (using dot- or bracket-notation) that resolves to a key in the object.
-`jq` calls it a "path expression".
+`jq` calls it a **path expression**.
 It is not sufficient to just give a string.
 
 ```jq

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -1,11 +1,11 @@
 # About
 
-Recursive functions are functions that call themselves.
+**Recursive functions** are functions that call themselves.
 
-A recursive function needs to have at least one _base case_ and at least one _recursive case_.
+A _recursive function_ needs to have at least one _base case_ and at least one _recursive case_.
 
-A _base case_ returns a value without calling the function again.
-A _recursive case_ calls the function again, modifying the input so that it will at some point match the base case.
+A **base case** returns a value without calling the function again.
+A **recursive case** calls the function again, modifying the input so that it will at some point match the base case.
 
 Here is an example that counts the elements of an array.
 
@@ -21,8 +21,8 @@ def count:
 ([11, 22, 33] | count)  # => 3
 ```
 
-A recursive function can have many base cases and/or many recursive cases.
-For example [the Fibonacci sequence][wiki-fibonacci] is a recursive sequence with two base cases.
+A _recursive function_ can have many _base cases_ and/or many _recursive cases_.
+For example [the Fibonacci sequence][wiki-fibonacci] is a recursive sequence with two _base cases_.
 
 ```jq
 def fibonacci:
@@ -37,7 +37,7 @@ def fibonacci:
 10 | fibonacci          # => 55
 ```
 
-Counting the number of occurrences of some given value `x` in a list has two recursive cases.
+Counting the number of occurrences of some given value `x` in a list has two _recursive cases_.
 
 ```jq
 def count_occurrences(x):

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -1,11 +1,11 @@
 # Introduction
 
-Recursive functions are functions that call themselves.
+**Recursive functions** are functions that call themselves.
 
-A recursive function needs to have at least one _base case_ and at least one _recursive case_.
+A _recursive function_ needs to have at least one _base case_ and at least one _recursive case_.
 
-A _base case_ returns a value without calling the function again.
-A _recursive case_ calls the function again, modifying the input so that it will at some point match the base case.
+A **base case** returns a value without calling the function again.
+A **recursive case** calls the function again, modifying the input so that it will at some point match the base case.
 
 Here is an example that counts the elements of an array.
 
@@ -21,8 +21,8 @@ def count:
 ([11, 22, 33] | count)  # => 3
 ```
 
-A recursive function can have many base cases and/or many recursive cases.
-For example [the Fibonacci sequence][wiki-fibonacci] is a recursive sequence with two base cases.
+A _recursive function_ can have many _base cases_ and/or many _recursive cases_.
+For example [the Fibonacci sequence][wiki-fibonacci] is a recursive sequence with two _base cases_.
 
 ```jq
 def fibonacci:
@@ -37,7 +37,7 @@ def fibonacci:
 10 | fibonacci          # => 55
 ```
 
-Counting the number of occurrences of some given value `x` in a list has two recursive cases.
+Counting the number of occurrences of some given value `x` in a list has two _recursive cases_.
 
 ```jq
 def count_occurrences(x):

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -1,7 +1,7 @@
 # About
 
 Recall that `jq` supports the same datatypes as JSON.
-JSON describes strings as:
+JSON describes **strings** as:
 
 > A string is a sequence of zero or more Unicode characters, wrapped in double quotes, using backslash escapes.
 
@@ -32,7 +32,7 @@ $ jq -cn --args  '$ARGS.positional[] | utf8bytelength' "Hello world!" "❄🌡�
 
 ## Substrings
 
-The ["slice" notation][slice] can be used to extract substrings.
+The [**slice** notation][slice] can be used to extract substrings.
 The syntax is `.[i:j]`.
 The substring returned is of length `j - i`, returning characters from index `i` (inclusive) to index `j` (exclusive).
 Either index can be negative, in which case it counts backwards from the end of the string.

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -1,7 +1,7 @@
 # Introduction
 
 Recall that `jq` supports the same datatypes as JSON.
-JSON describes strings as:
+JSON describes **strings** as:
 
 > A string is a sequence of zero or more Unicode characters, wrapped in double quotes, using backslash escapes.
 
@@ -25,7 +25,7 @@ $ jq -cn --args  '$ARGS.positional[] | length' "Hello world!" "❄🌡🤧🤒�
 
 ## Substrings
 
-The "slice" notation can be used to extract substrings.
+The **slice** notation can be used to extract substrings.
 The syntax is `.[i:j]`.
 The substring returned is of length `j - i`, returning characters from index `i` (inclusive) to index `j` (exclusive).
 Either index can be negative, in which case it counts backwards from the end of the string.

--- a/concepts/variables/about.md
+++ b/concepts/variables/about.md
@@ -1,7 +1,7 @@
 # Introduction
 
 Recall that a `jq` program is a _pipeline of expressions_.
-Variable assigmnent follows this rule: a variable assignment is an expression that looks like:
+**Variable assigmnent** follows this rule: a _variable assignment_ is an expression that looks like:
 
 ```jq
 ... | expr as $varname | ...
@@ -9,7 +9,7 @@ Variable assigmnent follows this rule: a variable assignment is an expression th
 
 ## The filter outputs the input
 
-Like the _identity expression_ `.`, the variable assignment's output is the same as its input.
+Like the _identity expression_ `.`, the _variable assignment_'s output is the same as its input.
 Setting the variable's value is a side-effect.
 
 Example, showing `.` after the assignment is the same as the initial input:
@@ -27,7 +27,7 @@ Variables defined in functions (we'll get to functions later) are "local" to the
 ## Variable names
 
 The variable must begin with `$`.
-The rest of the variable name is an "identifier": starts with a letter or underscore followed by letters, numbers or underscores.
+The rest of the variable name is an **identifier**: starts with a letter or underscore followed by letters, numbers or underscores.
 
 ## Destructuring assignment
 

--- a/concepts/variables/introduction.md
+++ b/concepts/variables/introduction.md
@@ -1,7 +1,7 @@
 # Introduction
 
 Recall that a `jq` program is a _pipeline of expressions_.
-Variable assigmnent follows this rule: a variable assignment is an expression that looks like:
+**Variable assigmnent** follows this rule: a _variable assignment_ is an expression that looks like:
 
 ```jq
 ... | expr as $varname | ...
@@ -9,7 +9,7 @@ Variable assigmnent follows this rule: a variable assignment is an expression th
 
 ## The filter outputs the input
 
-Like the _identity expression_ `.`, the variable assignment's output is the same as its input.
+Like the _identity expression_ `.`, the _variable assignment_'s output is the same as its input.
 Setting the variable's value is a side-effect.
 
 Example, showing `.` after the assignment is the same as the initial input:
@@ -27,7 +27,7 @@ Variables defined in functions (we'll get to functions later) are "local" to the
 ## Variable names
 
 The variable must begin with `$`.
-The rest of the variable name is an "identifier": starts with a letter or underscore followed by letters, numbers or underscores.
+The rest of the variable name is an **identifier**: starts with a letter or underscore followed by letters, numbers or underscores.
 
 ## Destructuring assignment
 

--- a/exercises/concept/assembly-line/.docs/introduction.md
+++ b/exercises/concept/assembly-line/.docs/introduction.md
@@ -6,7 +6,7 @@ From [the manual][man-types]
 
 > jq supports the same set of datatypes as JSON - numbers, strings, booleans, arrays, objects (which in JSON-speak are hashes with only string keys), and "null".
 
-Let's focus on *numbers*.
+Let's focus on **numbers**.
 
 ### Numbers and numeric operators
 
@@ -42,7 +42,7 @@ To solve the exercise, you will need to know about conditional expressions.
 
 #### Conditional Expressions
 
-`jq` uses an [`if-then-else` expression][if-then-else] for conditional expressions.
+`jq` uses an [`if-then-else` expression][if-then-else] for **conditional expressions**.
 As an _expression_, it is placed in a pipeline.
 
 Then syntax is: `if CONDITION then TRUE_EXPR else FALSE_EXPR end`.

--- a/exercises/concept/bird-count/.docs/introduction.md
+++ b/exercises/concept/bird-count/.docs/introduction.md
@@ -2,7 +2,7 @@
 
 ## Arrays
 
-JSON defines an array as:
+JSON defines an **array** as:
 
 > An array is an ordered collection of values.
 > An array begins with `[` left bracket and ends with `]` right bracket.
@@ -38,7 +38,7 @@ Retrieve an element from an array with a bracket expression:
 Negative indexes count backwards from the end of the array:
 `.[-1]` gets the last element; `.[-2]` is the second last.
 
-A "slice" is a sub-sequence of the array.
+A **slice** is a sub-sequence of the array.
 `.[10:15]` returns 5 elements starting from index 10; the end index is _not included_.
 
 There are some convenience functions:

--- a/exercises/concept/high-score-board/.docs/introduction.md
+++ b/exercises/concept/high-score-board/.docs/introduction.md
@@ -2,9 +2,9 @@
 
 ## Objects
 
-A JSON object is, to use terminology from other languages, a "hash", "map", or "dictionary".
+A JSON **object** is, to use terminology from other languages, a "hash", "map", or "dictionary".
 
-JSON defines an object as:
+JSON defines an _object_ as:
 
 > An object is an unordered set of **name**/**value** pairs.
 > An object begins with `{` left brace and ends with `}` right brace.
@@ -30,13 +30,13 @@ Note that there **must not** be a comma following the _last_ key-value pair.
 ### Creating objects
 
 Use braces to collect the name/value pairs.
-Even though the names must be strings, they do not need to be quoted if the names are "identifier-like" (composed of alphanumeric characters and underscore, and not started with a digit).
+Even though the names must be strings, they do not need to be quoted if the names are **identifier-like** (composed of alphanumeric characters and underscore, and not started with a digit).
 
 ```jq
 {name: "Jane", age: 42}
 ```
 
-It is valid to use keys that are not "identifier-like".
+It is valid to use keys that are not _identifier-like_.
 Just quote them.
 
 ```jq
@@ -55,13 +55,13 @@ $ echo "Jane" | jq -Rc '{(.): 42}'
 
 ### Indexing
 
-Values are retrieved from an object with _dot notation_.
+Values are retrieved from an object with **dot notation**.
 
 ```jq
 {name: "Jane", age: 42} | .age    # => 42
 ```
 
-If you cannot refer to the key as an identifier, use _bracket notation_.
+If you cannot refer to the key as an identifier, use **bracket notation**.
 
 ```jq
 "name" as $key | {name: "Jane", age: 42} | .$key    # => error
@@ -101,7 +101,7 @@ It returns the updated object.
 ```
 
 The parameter to `del` is an **index expression** (using dot- or bracket-notation) that resolves to a key in the object.
-`jq` calls it a "path expression".
+`jq` calls it a **path expression**.
 It is not sufficient to just give a string.
 
 ```jq

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -3,7 +3,7 @@
 ## Variables
 
 Recall that a `jq` program is a _pipeline of expressions_.
-Variable assigmnent follows this rule: a variable assignment is an expression that looks like:
+**Variable assigmnent** follows this rule: a _variable assignment_ is an expression that looks like:
 
 ```jq
 ... | expr as $varname | ...
@@ -11,7 +11,7 @@ Variable assigmnent follows this rule: a variable assignment is an expression th
 
 ### The filter outputs the input
 
-Like the _identity expression_ `.`, the variable assignment's output is the same as its input.
+Like the _identity expression_ `.`, the _variable assignment_'s output is the same as its input.
 Setting the variable's value is a side-effect.
 
 Example, showing `.` after the assignment is the same as the initial input:
@@ -29,7 +29,7 @@ Variables defined in functions (we'll get to functions later) are "local" to the
 ### Variable names
 
 The variable must begin with `$`.
-The rest of the variable name is an "identifier": starts with a letter or underscore followed by letters, numbers or underscores.
+The rest of the variable name is an **identifier**: starts with a letter or underscore followed by letters, numbers or underscores.
 
 ### Destructuring assignment
 

--- a/exercises/concept/log-line-parser/.docs/introduction.md
+++ b/exercises/concept/log-line-parser/.docs/introduction.md
@@ -3,7 +3,7 @@
 ## Strings
 
 Recall that `jq` supports the same datatypes as JSON.
-JSON describes strings as:
+JSON describes **strings** as:
 
 > A string is a sequence of zero or more Unicode characters, wrapped in double quotes, using backslash escapes.
 
@@ -27,7 +27,7 @@ $ jq -cn --args  '$ARGS.positional[] | length' "Hello world!" "❄🌡🤧🤒�
 
 ### Substrings
 
-The "slice" notation can be used to extract substrings.
+The **slice** notation can be used to extract substrings.
 The syntax is `.[i:j]`.
 The substring returned is of length `j - i`, returning characters from index `i` (inclusive) to index `j` (exclusive).
 Either index can be negative, in which case it counts backwards from the end of the string.

--- a/exercises/concept/recursive-functions/.docs/introduction.md
+++ b/exercises/concept/recursive-functions/.docs/introduction.md
@@ -2,12 +2,12 @@
 
 ## Recursion
 
-Recursive functions are functions that call themselves.
+**Recursive functions** are functions that call themselves.
 
-A recursive function needs to have at least one _base case_ and at least one _recursive case_.
+A _recursive function_ needs to have at least one _base case_ and at least one _recursive case_.
 
-A _base case_ returns a value without calling the function again.
-A _recursive case_ calls the function again, modifying the input so that it will at some point match the base case.
+A **base case** returns a value without calling the function again.
+A **recursive case** calls the function again, modifying the input so that it will at some point match the base case.
 
 Here is an example that counts the elements of an array.
 
@@ -23,8 +23,8 @@ def count:
 ([11, 22, 33] | count)  # => 3
 ```
 
-A recursive function can have many base cases and/or many recursive cases.
-For example [the Fibonacci sequence][wiki-fibonacci] is a recursive sequence with two base cases.
+A _recursive function_ can have many _base cases_ and/or many _recursive cases_.
+For example [the Fibonacci sequence][wiki-fibonacci] is a recursive sequence with two _base cases_.
 
 ```jq
 def fibonacci:
@@ -39,7 +39,7 @@ def fibonacci:
 10 | fibonacci          # => 55
 ```
 
-Counting the number of occurrences of some given value `x` in a list has two recursive cases.
+Counting the number of occurrences of some given value `x` in a list has two _recursive cases_.
 
 ```jq
 def count_occurrences(x):

--- a/exercises/concept/remote-control-car/.docs/introduction.md
+++ b/exercises/concept/remote-control-car/.docs/introduction.md
@@ -2,12 +2,12 @@
 
 ## Functions
 
-You can define your own custom functions in `jq` to encapsulate whatever logic you need.
-Functions act just like builtins: they take an input and emit zero, one or more outputs.
+You can define your own **custom functions** in `jq` to encapsulate whatever logic you need.
+_Functions_ act just like builtins: they take an input and emit zero, one or more outputs.
 
 ### Defining a function
 
-You can define a `jq` function using the following syntax:
+You can define a `jq` _function_ using the following syntax:
 
 ```jq
 # no arguments
@@ -25,7 +25,7 @@ def funcname(args): expression;
 
 ### Where to put functions
 
-Functions must be defined before they are used: this is an error:
+_Functions_ must be defined before they are used: this is an error:
 
 ```jq
 def A: B(10);
@@ -34,11 +34,11 @@ A
 # => error: B/1 is not defined
 ```
 
-This implies you have to place functions at the top of your jq code, prior to the "main" expression.
+This implies you have to place _functions_ at the top of your `jq` code, prior to the "main" expression.
 
 #### Nested functions
 
-Functions can be nested:
+_Functions_ can be nested:
 
 ```jq
 def A:
@@ -49,16 +49,16 @@ A
 # => 11
 ```
 
-Here, the `B` function is only visible in the body of `A`.
+Here, the `B` _function_ is only visible in the body of `A`.
 
 ### Scope
 
-A function introduces a new scope for variables and nested functons.
+A _function_ introduces a new **scope** for variables and nested functons.
 
 ### Arguments
 
-Function arguments are separated by _semi-colons_ not commas.
-For example, a function that takes a number, and then adds a number and multiplies by a number:
+_Function_ arguments are separated by _semi-colons_ not commas.
+For example, a _function_ that takes a number, and then adds a number and multiplies by a number:
 
 ```jq
 def add_mul(adder; multiplier): (. + adder) * multiplier;
@@ -79,7 +79,7 @@ Using a comma instead of a semi-colon will attempt to call a _1-argument_ `add_m
 
 #### Arguments are _expressions_
 
-Function arguments are filters, not values.
+**Function arguments** are filters, not values.
 In this sense, they act like what other languages describe as callbacks:
 
 Using the `add_mul` function as an example:
@@ -99,7 +99,7 @@ What's happening here?
 
 #### Arguments as values
 
-Sometimes you'll want to "materialize" an argument into a variable:
+Sometimes you'll want to "materialize" an _argument_ into a variable:
 
 ```jq
 def my_func(arg):
@@ -116,13 +116,13 @@ def my_func($arg):
 ;
 ```
 
-Take note that this is just "syntactic sugar": the name `arg` with no `$` is still in scope in the function.
+Take note that this is just "syntactic sugar": the name `arg` with no `$` is still in scope in the _function_.
 
 ### Arity
 
-Functions have an "arity" -- the number of arguments they take.
+_Functions_ have an **arity** -- the number of _arguments_ they take.
 
-Functions can use the same name with different arities.
+_Functions_ can use the same name with different _arities_.
 The builtin [`range`][man-range] function demonstrates this: `range/1`, `range/2` and `range/3` all co-exist.
 
 This can be useful for defining recursive functions that carry state via arguments.

--- a/exercises/concept/shopping/.docs/introduction.md
+++ b/exercises/concept/shopping/.docs/introduction.md
@@ -37,14 +37,14 @@ The rest of this lesson will focus on the `jq` _lanaguage_.
 
 ### Filters and Pipes
 
-Filters are also known as Expressions.
+**Filters** are also known as **Expressions**.
 
-A filter takes an input and produces an output.
-Like the way you work in a unix shell, you can join filters with a pipe `|` to connect the output of one filter to the input of another.
+A _filter_ takes an input and produces an output.
+Like the way you work in a unix shell, you can join _filters_ with a pipe `|` to connect the output of one _filter_ to the input of another.
 
 ### The Identity Filter: `.`
 
-This is the simplest filter.
+This is the simplest _filter_.
 It simply passes its input to its output.
 
 ```sh
@@ -58,17 +58,17 @@ $ echo '[1, 2, 3]' | jq '.'
 
 ### Arrays
 
-This will be quick introduction to working with arrays.
+This will be quick introduction to working with **arrays**.
 We will cover this topic in greater detail later.
 
-Array elements are accessed with brackets, and are zero-indexed.
+_Array_ elements are accessed with brackets, and are zero-indexed.
 
 ```sh
 $ echo '[10, 20, 30]' | jq '.[1]'
 20
 ```
 
-A filter can build an array by wrapping an expression in `[` and `]`
+A _filter_ can build an _array_ by wrapping an expression in `[` and `]`
 
 - with a known list of elements:
 
@@ -96,19 +96,19 @@ A filter can build an array by wrapping an expression in `[` and `]`
 
 ### Comma is an operator
 
-The comma is not just syntax that separates array elements.
-Comma is an **operator** that joins streams.
+The _comma_ is not just syntax that separates _array_ elements.
+**Comma** is an **operator** that joins streams.
 
-For example `[1, 2, 3]` is a filter that uses the array constructor `[]` to collect the result of joining the three expressions `1`, `2` and `3`.
+For example `[1, 2, 3]` is a _filter_ that uses the _arraya_ constructor `[]` to collect the result of joining the three expressions `1`, `2` and `3`.
 
 Did you notice the semi-colons in `range(10; 70; 15)` above?
-Because commas have a specific purpose in the `jq` language, functions that take multiple arguments use semi-colons to separate the arguments.
+Because _commas_ have a specific purpose in the `jq` language, functions that take multiple arguments use semi-colons to separate the arguments.
 
 ### Objects
 
-A quick introduction to objects.
+A quick introduction to **objects**.
 
-Similar to many programming languages, use dots to access object properties
+Similar to many programming languages, use dots to access _object_ properties
 
 ```sh
 $ echo '{"foo": {"bar": "qux"}}' | jq '.foo.bar'
@@ -117,7 +117,7 @@ $ echo '{"foo": {"bar": "qux"}}' | jq '.foo.bar'
 
 <!-- prettier-ignore -->
 ~~~~exercism/note
-Brackets can be used for objects too, but then quotes are needed for string literals.
+Brackets can be used for _objects_ too, but then quotes are needed for string literals.
 This is one method to work with keys containing spaces.
 
 ```sh
@@ -128,8 +128,8 @@ $ echo '{"foo bar": "qux"}' | jq '.["foo bar"]'
 
 <!-- prettier-ignore-end -->
 
-You can construct an object with `{}` and `key: value` pairs.
-Quotes are not required around keys that are "simple" strings.
+You can construct an _object_ with `{}` and `key: value` pairs.
+Quotes are not required around _keys_ that are "simple" strings.
 
 ```sh
 jq -n '{question: 6 * 9, answer: 42}'
@@ -144,7 +144,7 @@ outputs
 }
 ```
 
-To treat the key as an _expression_, you must wrap it in parentheses
+To treat the _key_ as an _expression_, you must wrap it in parentheses
 
 ```sh
 echo '[{"key":"question", "value":54}, {"key":"answer", "value":42}]' \
@@ -153,7 +153,7 @@ echo '[{"key":"question", "value":54}, {"key":"answer", "value":42}]' \
 
 ### Pipelines
 
-For example, given "file.json" containing
+For example, given `file.json` containing
 
 ```json
 {
@@ -162,14 +162,14 @@ For example, given "file.json" containing
 }
 ```
 
-Let's calculate the length of the key2 array:
+Let's calculate the length of the key2 _array_:
 
 ```sh
 $ jq '.key2 | length' file.json
 3
 ```
 
-We're _piping_ the output of the `.key2` expression as the input to `length` which unsurprisingly outputs the number of elements in the array.
+We're _piping_ the output of the `.key2` expression as the input to `length` which unsurprisingly outputs the number of elements in the _array_.
 
 ### Filters can ignore their input
 
@@ -182,8 +182,8 @@ $ echo '{"answer": 42}' | jq '6 * 9'
 
 ### Filters can output streams of data
 
-A filter can output more than one value.
-For example, the `.[]` filter outputs each element of an array as a separate value:
+A _filter_ can output more than one value.
+For example, the `.[]` _filter_ outputs each element of an _array_ as a separate value:
 
 ```sh
 $ jq -n -c '[1, 2, 3]'
@@ -195,7 +195,7 @@ $ jq -n -c '[1, 2, 3] | .[]'
 3
 ```
 
-Piping such a filter into another will execute the 2nd filter **_for each value_**:
+Piping such a _filter_ into another will execute the 2nd _filter_ **_for each value_**:
 
 ```sh
 $ jq -n -c '[1, 2, 3] | .[] | . * 2'
@@ -205,16 +205,16 @@ $ jq -n -c '[1, 2, 3] | .[] | . * 2'
 ```
 
 This is like implicit iteration.
-Once you understand this technique, you'll realize very powerful jq filters can be very concise.
+Once you understand this technique, you'll realize very powerful `jq` _filters_ can be very concise.
 
 ### Parentheses
 
-Parentheses are used to group sub-expressions together to enforce the order of operations, just like in other languages.
+**Parentheses** are used to group sub-expressions together to enforce the order of operations, just like in other languages.
 In `jq`, the need for them can appear to be somewhat surprising.
 
-For example, let's say we want to construct an array with 2 elements: the square root of 9; and _e_ raised to the power 1.
+For example, let's say we want to construct an _array_ with 2 elements: the square root of 9; and _e_ raised to the power 1.
 The two individual expressions are `9 | sqrt` and `1 | exp`.
-We expect the output to be the array `[3, 2.7...]`
+We expect the output to be the _array_ `[3, 2.7...]`
 
 ```jq
 $ jq -n '[ 9|sqrt, 1|exp ]'
@@ -293,7 +293,7 @@ Without going into great depth (functions will be a topic for another exercise),
 
   Given _some_ input and a filter as an argument:
 
-  - if the filter applied to the argument results in a **true** value, output the input unchanged
+  - if the filter applied to the argument results in a _true_ value, output the input unchanged
   - otherwise, output _nothing_ (not the `null` value, truly no output)
 
   For example, given some numbers, select the ones divisible by 3

--- a/exercises/concept/vehicle-purchase/.docs/introduction.md
+++ b/exercises/concept/vehicle-purchase/.docs/introduction.md
@@ -29,7 +29,7 @@ The result of the comparison is always a boolean value, so either `true` or `fal
 
 The comparison operators above can also be used to compare strings.
 In that case, a dictionary (lexicographical) order is applied.
-The ordering is "by unicode codepoint value".
+The ordering is _by unicode codepoint value_.
 
 ```jq
 "Apple" > "Pear",   # => false
@@ -84,9 +84,9 @@ Two objects are equal if they have the same key-value pairs.
 
 ### If Expression
 
-`jq`'s conditional expression is `if A then B else C end`.
+`jq`'s **conditional expression** is `if A then B else C end`.
 
-`if-then-else` is a filter like all jq builtins: it takes an input and produces an output.
+`if-then-else` is a filter like all `jq` builtins: it takes an input and produces an output.
 
 If the expression `A` produces a "truthy" value, then the `if` filter evaluates `B`.
 Otherwise it evaluates `C`.
@@ -122,7 +122,7 @@ Everything else is "true", even the number zero and the empty string, array and 
 
 ### Boolean Operators
 
-The boolean operators `and` and `or` can be used to build complex queries.
+The **boolean operators** `and` and `or` can be used to build complex queries.
 
 ```jq
 42 | if . < 33 or . > 66 then "big or small"
@@ -140,7 +140,7 @@ To negate, use `not`. This is a **filter** not an operator.
 
 ### Alternative Operator
 
-The alternative operator allows you to specify a "default" value if an expression is false or null.
+The **alternative operator** allows you to specify a "default" value if an expression is false or null.
 
 ```jq
 A // B


### PR DESCRIPTION
## Summary

Expands a sidenote in the "about" document for Functions concept: why can't we use commas to separate arguments.

Closes #85 

## Checklist
- [x] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
