### PR TITLE
[Bird Count] Test solutions uses correct array access

### DIFF
--- a/exercises/concept/bird-count/test-bird-count.bats
+++ b/exercises/concept/bird-count/test-bird-count.bats
@@ -16,56 +16,56 @@ assert_key_value() {
 
 @test yesterday_for_disappointing_week {
     ## task 2
-    run jq -f bird-count.jq <<< '[[0, 0, 1, 0, 0, 1, 0]]'
+    run jq -f bird-count.jq <<< '[[8, 8, 9, 5, 4, 7, 10],[0, 0, 1, 0, 0, 1, 0]]'
     assert_success
     assert_key_value 'yesterday' 1
 }
 
 @test yesterday_for_busy_week {
     ## task 2
-    run jq -f bird-count.jq <<< '[[8, 8, 9, 5, 4, 7, 10]]'
+    run jq -f bird-count.jq <<< '[[0, 0, 1, 0, 0, 1, 0],[8, 8, 9, 5, 4, 7, 10]]'
     assert_success
     assert_key_value 'yesterday' 7
 }
 
 @test total_for_disappointing_week {
     ## task 3
-    run jq -f bird-count.jq <<< '[[0, 0, 1, 0, 0, 1, 0]]'
+    run jq -f bird-count.jq <<< '[[8, 8, 9, 5, 4, 7, 10],[0, 0, 1, 0, 0, 1, 0]]'
     assert_success
     assert_key_value 'total' 2
 }
 
 @test total_for_busy_week {
     ## task 3
-    run jq -f bird-count.jq <<< '[[5, 9, 12, 6, 8, 8, 17]]'
+    run jq -f bird-count.jq <<< '[[0, 0, 1, 0, 0, 1, 0],[5, 9, 12, 6, 8, 8, 17]]'
     assert_success
     assert_key_value 'total' 65
 }
 
 @test busy_days_for_dissapointing_week {
     ## task 4
-    run jq -f bird-count.jq <<< '[[1, 1, 1, 0, 0, 0, 0]]'
+    run jq -f bird-count.jq <<< '[[8, 8, 9, 5, 4, 7, 10],[1, 1, 1, 0, 0, 0, 0]]'
     assert_success
     assert_key_value 'busy_days' 0
 }
 
 @test busy_days_for_busy_week {
     ## task 4
-    run jq -f bird-count.jq <<< '[[4, 9, 5, 7, 8, 8, 2]]'
+    run jq -f bird-count.jq <<< '[[1, 1, 1, 0, 0, 0, 0],[4, 9, 5, 7, 8, 8, 2]]'
     assert_success
     assert_key_value 'busy_days' 5
 }
 
 @test has_day_without_birds {
     ## task 5
-    run jq -f bird-count.jq <<< '[[5, 5, 4, 0, 7, 6]]'
+    run jq -f bird-count.jq <<< '[[4, 9, 5, 7, 8, 8, 2],[5, 5, 4, 0, 7, 6]]'
     assert_success
     assert_key_value 'has_day_without_birds' true
 }
 
 @test has_day_without_birds_whith_no_day_without_birds {
     ## task 5
-    run jq -f bird-count.jq <<< '[[4, 5, 9, 10, 9, 4, 3]]'
+    run jq -f bird-count.jq <<< '[[1, 1, 1, 0, 0, 0, 0],[4, 5, 9, 10, 9, 4, 3]]'
     assert_success
     assert_key_value 'has_day_without_birds' false
 }


### PR DESCRIPTION
## Summary

This PR expands and fixes the `Bird Count` test suite, to make sure that solutions use the correct array access.

## Reasoning for fix

When I solved this, I used `first` instead of `last` to access the nested array. While this passes the original test, it does not match the instructions. This is due to the test suite only using a single nested array, given the original test, my solution outputs.

```json
{
  "last_week": [
    0,
    2,
    5,
    3,
    7,
    8,
    4
  ],
  "yesterday": 1,
  "total": 2,
  "busy_days": 0,
  "has_day_without_birds": true
}
```

While the expected solutions should output the following.

```json
{
  "last_week": [
    0,
    2,
    5,
    3,
    7,
    8,
    4
  ],
  "yesterday": 4,
  "total": 44,
  "busy_days": 4,
  "has_day_without_birds": false
}
```

With this updated test, my solution using `first` fails, since it now test that the correct week is accessed.

## Checklist

![CLI session of test validation](https://user-images.githubusercontent.com/2221746/213418317-c4ac212e-3fea-4db4-a4e0-06b2807f5e7b.gif)
