### PR TITLE
Fix typo in Variables concept

### DIFF
--- a/concepts/variables/about.md
+++ b/concepts/variables/about.md
@@ -72,7 +72,7 @@ The same shortcut works in the reverse sense for _object construction_
 
 ## Constants
 
-As shows in the above example, variables are handy for storing constants.
+As shown in the above example, variables are handy for storing constants.
 It's better to give constants a name rather than have "magic numbers" show up in the code.
 
 ## Often variables are not needed

--- a/concepts/variables/introduction.md
+++ b/concepts/variables/introduction.md
@@ -72,7 +72,7 @@ The same shortcut works in the reverse sense for _object construction_
 
 ## Constants
 
-As shows in the above example, variables are handy for storing constants.
+As shown in the above example, variables are handy for storing constants.
 It's better to give constants a name rather than have "magic numbers" show up in the code.
 
 ## Often variables are not needed

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -74,7 +74,7 @@ The same shortcut works in the reverse sense for _object construction_
 
 ### Constants
 
-As shows in the above example, variables are handy for storing constants.
+As shown in the above example, variables are handy for storing constants.
 It's better to give constants a name rather than have "magic numbers" show up in the code.
 
 ### Often variables are not needed


### PR DESCRIPTION
## Summary

This fixes a typo in the Variables concept text.

## Checklist
- [x] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
