### PR TITLE
Add note on output

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -133,7 +133,7 @@ outputs
 }
 ```
 
-To treat the _key_ as an _expression_, you must wrap it in parentheses
+To treat the _key_ as an _expression_, you must wrap it in parentheses (the following also outputs the same as above).
 
 ```sh
 echo '[["question", "answer"], [54, 42]]' \

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -149,6 +149,8 @@ echo '[{"key":"question", "value":54}, {"key":"answer", "value":42}]' \
 | jq '{(.[0].key): .[0].value, (.[1].key): .[1].value}'
 ```
 
+This also outputs the same as above.
+
 ## Pipelines
 
 For example, given `file.json` containing

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -142,14 +142,12 @@ outputs
 }
 ```
 
-To treat the _key_ as an _expression_, you must wrap it in parentheses
+To treat the _key_ as an _expression_, you must wrap it in parentheses (the following also outputs the same as above).
 
 ```sh
 echo '[{"key":"question", "value":54}, {"key":"answer", "value":42}]' \
 | jq '{(.[0].key): .[0].value, (.[1].key): .[1].value}'
 ```
-
-This also outputs the same as above.
 
 ## Pipelines
 

--- a/exercises/concept/shopping/.docs/introduction.md
+++ b/exercises/concept/shopping/.docs/introduction.md
@@ -144,7 +144,7 @@ outputs
 }
 ```
 
-To treat the _key_ as an _expression_, you must wrap it in parentheses
+To treat the _key_ as an _expression_, you must wrap it in parentheses (the following also outputs the same as above).
 
 ```sh
 echo '[{"key":"question", "value":54}, {"key":"answer", "value":42}]' \


### PR DESCRIPTION
Great intro! I thought it might be useful for the reader to know that the output of the 

```sh
echo '[{"key":"question", "value":54}, {"key":"answer", "value":42}]' \
| jq '{(.[0].key): .[0].value, (.[1].key): .[1].value}'
```

was also the same as the previous example.

But also I wanted to give kudos for that very subtle reference to the scene with Arthur, Ford and the caveman in The Hitch-Hiker's Guide to the Galaxy (Fit the Sixth). That's made my day :-)


## Checklist
- [ ] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
