### PR TITLE
minor grammar and JSON syntax tweak

### DIFF
--- a/concepts/objects/about.md
+++ b/concepts/objects/about.md
@@ -12,7 +12,7 @@ The _name_ **must be a string**.
 Another word for _name_ is _key_.
 
 The _value_ can be of any JSON type.
-Different _values_ in the same object can be different type, like this example.
+Different _values_ in the same object can be of different types, like this example.
 
 <!-- prettier-ignore -->
 ```json
@@ -163,7 +163,7 @@ Use the `del` function to remove a key.
 It returns the updated object.
 
 ```jq
-{name: "Jane", age: 42} | del(.age)   # => {name: "Jane"}
+{name: "Jane", age: 42} | del(.age)   # => {"name": "Jane"}
 ```
 
 The parameter to `del` is an **index expression** (using dot- or bracket-notation) that resolves to a key in the object.

--- a/concepts/objects/introduction.md
+++ b/concepts/objects/introduction.md
@@ -12,7 +12,7 @@ The _name_ **must be a string**.
 Another word for _name_ is _key_.
 
 The _value_ can be of any JSON type.
-Different _values_ in the same object can be different type, like this example.
+Different _values_ in the same object can be of different types, like this example.
 
 <!-- prettier-ignore -->
 ```json
@@ -98,7 +98,7 @@ Use the `del` function to remove a key.
 It returns the updated object.
 
 ```jq
-{name: "Jane", age: 42} | del(.age)   # => {name: "Jane"}
+{name: "Jane", age: 42} | del(.age)   # => {"name": "Jane"}
 ```
 
 The parameter to `del` is an **index expression** (using dot- or bracket-notation) that resolves to a key in the object.

--- a/exercises/concept/high-score-board/.docs/introduction.md
+++ b/exercises/concept/high-score-board/.docs/introduction.md
@@ -14,7 +14,7 @@ The _name_ **must be a string**.
 Another word for _name_ is _key_.
 
 The _value_ can be of any JSON type.
-Different _values_ in the same object can be different type, like this example.
+Different _values_ in the same object can be of different types, like this example.
 
 <!-- prettier-ignore -->
 ```json
@@ -100,7 +100,7 @@ Use the `del` function to remove a key.
 It returns the updated object.
 
 ```jq
-{name: "Jane", age: 42} | del(.age)   # => {name: "Jane"}
+{name: "Jane", age: 42} | del(.age)   # => {"name": "Jane"}
 ```
 
 The parameter to `del` is an **index expression** (using dot- or bracket-notation) that resolves to a key in the object.


### PR DESCRIPTION
## Summary

Very minor updates to the `about.md` / `introduction.md` files for the objects concept docu:

* changed grammar of a sentence so it would be more comprehensible
* corrected the sample JSON output for one of the examples (all the other output examples were JSON, and `jq` emits JSON unless told otherwise, so it made sense that this correction would be useful)


## Checklist
- [X] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
