### PR TITLE
Fix Types and Values link in Strings concept

### DIFF
--- a/concepts/strings/links.json
+++ b/concepts/strings/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#TypesandValues]",
+    "url": "https://stedolan.github.io/jq/manual/v1.6/#TypesandValues",
     "description": "Types and Values"
   },
   {


### PR DESCRIPTION
## Summary

Remove extra character from link to manual

## Checklist
- [ ] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
