### PR TITLE
Fix typo "shorhand"

### DIFF
--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -119,7 +119,7 @@ def my_func(arg):
 ;
 ```
 
-There's a shorhand for this:
+There's a shorthand for this:
 
 ```jq
 def my_func($arg):

--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -109,7 +109,7 @@ def my_func(arg):
 ;
 ```
 
-There's a shorhand for this:
+There's a shorthand for this:
 
 ```jq
 def my_func($arg):

--- a/exercises/concept/remote-control-car/.docs/introduction.md
+++ b/exercises/concept/remote-control-car/.docs/introduction.md
@@ -111,7 +111,7 @@ def my_func(arg):
 ;
 ```
 
-There's a shorhand for this:
+There's a shorthand for this:
 
 ```jq
 def my_func($arg):


### PR DESCRIPTION
## Summary

This fixes a typo in the jq docs, "shorhand".

## Checklist
- [x] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
