### PR TITLE
Fix typo in arrays doc

### DIFF
--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -129,7 +129,7 @@ otherwise the funtion returns `null`.
 ```
 
 There is an inverse function called `IN` (yes, in capital letters).
-The wrinkle with `IN` is that it's argument is not an array, but a _stream_.
+The wrinkle with `IN` is that its argument is not an array, but a _stream_.
 
 ```jq
 "beef" | IN(["carrots", "beef", "potatoes"][])    # => true


### PR DESCRIPTION
## Summary

Fix a typo in the array concepts doc.

## Checklist
- [x] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
