### PR TITLE
exercises(grade-stats): fix link in admonition

### DIFF
--- a/exercises/concept/grade-stats/.docs/introduction.md
+++ b/exercises/concept/grade-stats/.docs/introduction.md
@@ -73,7 +73,7 @@ The `add` builtin is actually [implemented with `reduce`][jq-code-add], but uses
 def add: reduce .[] as $x (null; . + $x);
 ```
 
-
+[jq-code-add]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L11
 ~~~~
 
 <!-- prettier-ignore-end -->
@@ -97,6 +97,5 @@ def add: reduce .[] as $x (null; . + $x);
   | reduce .[] as $elem ([]; [$elem] + .)       # => ["D", "C", "B", "A"]
   ```
 
-[jq-code-add]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L11
 [jq-man-reduce]: https://stedolan.github.io/jq/manual/v1.6/#Reduce
 [jq-man-iterator]: https://stedolan.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]


### PR DESCRIPTION
## Summary

There was a [bug in `configlet generate`][1] that caused link reference definitions to be moved out of an admonition. That caused the link to be [broken in the introduction for this exercise][2].

With configlet 4.0.0-beta.10 (2023-03-23), `configlet generate` will keep the link reference definition inside the admonition.

[1]: https://github.com/exercism/configlet/issues/737
[2]: https://exercism.org/tracks/jq/exercises/grade-stats/edit

## Checklist

- [x] Wait for configlet 4.0.0-beta.10 release
- [x] If docs were changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green