### PR TITLE
updated links to jqlang.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Unless we provide it as a library to include ...
 
 JBOL includes an implementation of [pseudo-random numbers][jbol-chance].
 
-[numbers]: https://github.com/stedolan/jq/wiki/FAQ#numbers
+[numbers]: https://github.com/jqlang/jq/wiki/FAQ#numbers
 [jbol-bitwise]: https://github.com/fadado/JBOL/blob/master/fadado.github.io/math/bitwise.jq
 [jbol-chance]: https://github.com/fadado/JBOL/blob/master/fadado.github.io/math/chance.jq
 

--- a/concepts/arrays/links.json
+++ b/concepts/arrays/links.json
@@ -4,7 +4,7 @@
     "description": "Reshaping JSON with jq"
   },
   {
-    "url": "https://github.com/stedolan/jq/wiki/jq-Language-Description#Array-and-Object-Accessors-and-Iterators",
+    "url": "https://github.com/jqlang/jq/wiki/jq-Language-Description#array-and-object-accessors-and-iterators",
     "description": "Array and Object Accessors and Iterators"
   }
 ]

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -379,11 +379,11 @@ Without going into great depth (functions will be a topic for another exercise),
 
 Comments start with a `#` character and continue to the end of the line.
 
-[man-cli]: https://stedolan.github.io/jq/manual/v1.6/#Invokingjq
-[man-types]: https://stedolan.github.io/jq/manual/v1.6/#TypesandValues
-[man-length]: https://stedolan.github.io/jq/manual/v1.6/#length
-[man-range]: https://stedolan.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
-[man-map]: https://stedolan.github.io/jq/manual/v1.6/#map(x),map_values(x)
-[man-plus]: https://stedolan.github.io/jq/manual/v1.6/#Addition:+
-[man-add]: https://stedolan.github.io/jq/manual/v1.6/#add
-[man-select]: https://stedolan.github.io/jq/manual/v1.6/#select(boolean_expression)
+[man-cli]: https://jqlang.github.io/jq/manual/v1.6/#Invokingjq
+[man-types]: https://jqlang.github.io/jq/manual/v1.6/#TypesandValues
+[man-length]: https://jqlang.github.io/jq/manual/v1.6/#length
+[man-range]: https://jqlang.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
+[man-map]: https://jqlang.github.io/jq/manual/v1.6/#map(x),map_values(x)
+[man-plus]: https://jqlang.github.io/jq/manual/v1.6/#Addition:+
+[man-add]: https://jqlang.github.io/jq/manual/v1.6/#add
+[man-select]: https://jqlang.github.io/jq/manual/v1.6/#select(boolean_expression)

--- a/concepts/basics/links.json
+++ b/concepts/basics/links.json
@@ -1,14 +1,14 @@
 [
   {
-    "url": "https://github.com/stedolan/jq/wiki/jq-Language-Description#jq-Program-Structure-and-Basic-Syntax",
+    "url": "https://github.com/jqlang/jq/wiki/jq-Language-Description#jq-program-structure-and-basic-syntax",
     "description": "jq Program Structure and Basic Syntax"
   },
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#Basicfilters",
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#Basicfilters",
     "description": "Basic filters"
   },
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#TypesandValues]",
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#TypesandValues]",
     "description": "Types and Values"
   }
 ]

--- a/concepts/compare/about.md
+++ b/concepts/compare/about.md
@@ -29,7 +29,7 @@ The comparison operators above can also be used to compare strings.
 In that case, a dictionary (lexicographical) order is applied.
 The ordering is [by unicode codepoint value][sort].
 
-[sort]: https://stedolan.github.io/jq/manual/v1.6/#sort,sort_by(path_expression)
+[sort]: https://jqlang.github.io/jq/manual/v1.6/#sort,sort_by(path_expression)
 
 ```jq
 "Apple" > "Pear",   # => false

--- a/concepts/compare/links.json
+++ b/concepts/compare/links.json
@@ -1,10 +1,10 @@
 [
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#%3E,%3E=,%3C=,%3C",
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#%3E,%3E=,%3C=,%3C",
     "description": "Relational operators"
   },
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#==,!=",
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#==,!=",
     "description": " operators"
   },
   {

--- a/concepts/conditionals/links.json
+++ b/concepts/conditionals/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#if-then-else",
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#if-then-else",
     "description": "The if-then-else expression"
   }
 ]

--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -202,7 +202,7 @@ def my_map(func):
 A `jq` module is a file containing only functions.
 Modules are included into a jq program with the [`include`][man-include] or [`import`][man-import] commands.
 
-[man-range]: https://stedolan.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
+[man-range]: https://jqlang.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
 
-[man-import]: https://stedolan.github.io/jq/manual/v1.6/#importRelativePathStringasNAME[%3Cmetadata%3E];
-[man-include]: https://stedolan.github.io/jq/manual/v1.6/#includeRelativePathString[%3Cmetadata%3E];
+[man-import]: https://jqlang.github.io/jq/manual/v1.6/#importRelativePathStringasNAME[%3Cmetadata%3E];
+[man-include]: https://jqlang.github.io/jq/manual/v1.6/#includeRelativePathString[%3Cmetadata%3E];

--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -153,7 +153,7 @@ def my_map(func):
 A `jq` module is a file containing only functions.
 Modules are included into a jq program with the [`include`][man-include] or [`import`][man-import] commands.
 
-[man-range]: https://stedolan.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
+[man-range]: https://jqlang.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
 
-[man-import]: https://stedolan.github.io/jq/manual/v1.6/#importRelativePathStringasNAME[%3Cmetadata%3E];
-[man-include]: https://stedolan.github.io/jq/manual/v1.6/#includeRelativePathString[%3Cmetadata%3E];
+[man-import]: https://jqlang.github.io/jq/manual/v1.6/#importRelativePathStringasNAME[%3Cmetadata%3E];
+[man-include]: https://jqlang.github.io/jq/manual/v1.6/#includeRelativePathString[%3Cmetadata%3E];

--- a/concepts/functions/links.json
+++ b/concepts/functions/links.json
@@ -1,14 +1,14 @@
 [
   {
     "description": "\"Defining Functions\" in the manual",
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#DefiningFunctions"
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#DefiningFunctions"
   },
   {
     "description": "\"Advanced Topics\" in the wiki",
-    "url": "https://github.com/stedolan/jq/wiki/Advanced-Topics"
+    "url": "https://github.com/jqlang/jq/wiki/Advanced-Topics"
   },
   {
     "description": "\"Modules\" in the manual",
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#Modules"
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#Modules"
   }
 ]

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -83,6 +83,6 @@ Additional conditions use `elif`
 # => "medium"
 ```
 
-[man-types]: https://stedolan.github.io/jq/manual/v1.6/#TypesandValues
-[man-math]: https://stedolan.github.io/jq/manual/v1.6/#Math
-[if-then-else]: https://stedolan.github.io/jq/manual/v1.6/#if-then-else
+[man-types]: https://jqlang.github.io/jq/manual/v1.6/#TypesandValues
+[man-math]: https://jqlang.github.io/jq/manual/v1.6/#Math
+[if-then-else]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -61,6 +61,6 @@ Additional conditions use `elif`
 # => "medium"
 ```
 
-[man-types]: https://stedolan.github.io/jq/manual/v1.6/#TypesandValues
-[man-math]: https://stedolan.github.io/jq/manual/v1.6/#Math
-[if-then-else]: https://stedolan.github.io/jq/manual/v1.6/#if-then-else
+[man-types]: https://jqlang.github.io/jq/manual/v1.6/#TypesandValues
+[man-math]: https://jqlang.github.io/jq/manual/v1.6/#Math
+[if-then-else]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else

--- a/concepts/numbers/links.json
+++ b/concepts/numbers/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#TypesandValues]",
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#TypesandValues]",
     "description": "Types and Values"
   },
   {

--- a/concepts/objects/links.json
+++ b/concepts/objects/links.json
@@ -1,10 +1,10 @@
 [
   {
-    "url": "https://github.com/stedolan/jq/wiki/jq-Language-Description#Array-and-Object-Accessors-and-Iterators",
+    "url": "https://github.com/jqlang/jq/wiki/jq-language-description#array-and-object-accessors-and-iterators",
     "description": "Array and Object Accessors and Iterators"
   },
   {
-    "url": "https://stedolan.github.io/jq/tutorial/",
+    "url": "https://jqlang.github.io/jq/tutorial/",
     "description": "jq Tutorial"
   }
 ]

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -104,8 +104,8 @@ def fibonacci:
 10 | fibonacci          # => 55
 ```
 
-[map-implementation]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L3
-[range-implementation]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L157
+[map-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L3
+[range-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L157
 [wiki-fibonacci]: https://en.wikipedia.org/wiki/Fibonacci_number
 [wiki-tail-call]: https://en.wikipedia.org/wiki/Tail_call
 [wiki-call-stack]: https://en.wikipedia.org/wiki/Call_stack

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -56,6 +56,6 @@ In practice, iterating over lists and other enumerable data structures is most o
 such as `map` and `reduce`, or by [using streams][map-implementation] like `[.[] | select(...)]`.
 Under the hood, some builtins are [implemented using recursion][range-implementation].
 
-[map-implementation]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L3
-[range-implementation]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L157
+[map-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L3
+[range-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L157
 [wiki-fibonacci]: https://en.wikipedia.org/wiki/Fibonacci_number

--- a/concepts/recursion/links.json
+++ b/concepts/recursion/links.json
@@ -1,10 +1,10 @@
 [
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#Recursion",
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#Recursion",
     "description": "Recursion in the manual"
   },
   {
-    "url": "https://github.com/stedolan/jq/wiki/Advanced-Topics#recursion-and-tail-recursion-optimization",
+    "url": "https://github.com/jqlang/jq/wiki/Advanced-Topics#recursion-and-tail-recursion-optimization",
     "description": "jq Advanced Topics - Recursion and Tail Recursion Optimization"
   },
   {

--- a/concepts/reduce/about.md
+++ b/concepts/reduce/about.md
@@ -71,7 +71,7 @@ The `add` builtin is actually [implemented with `reduce`][jq-code-add], but uses
 def add: reduce .[] as $x (null; . + $x);
 ```
 
-[jq-code-add]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L11
+[jq-code-add]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L11
 ~~~~
 
 <!-- prettier-ignore-end -->
@@ -95,6 +95,6 @@ def add: reduce .[] as $x (null; . + $x);
   | reduce .[] as $elem ([]; [$elem] + .)       # => ["D", "C", "B", "A"]
   ```
 
-[jq-man-reduce]: https://stedolan.github.io/jq/manual/v1.6/#Reduce
+[jq-man-reduce]: https://jqlang.github.io/jq/manual/v1.6/#Reduce
 
-[jq-man-iterator]: https://stedolan.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]
+[jq-man-iterator]: https://jqlang.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]

--- a/concepts/reduce/introduction.md
+++ b/concepts/reduce/introduction.md
@@ -71,7 +71,7 @@ The `add` builtin is actually [implemented with `reduce`][jq-code-add], but uses
 def add: reduce .[] as $x (null; . + $x);
 ```
 
-[jq-code-add]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L11
+[jq-code-add]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L11
 ~~~~
 
 <!-- prettier-ignore-end -->
@@ -95,6 +95,6 @@ def add: reduce .[] as $x (null; . + $x);
   | reduce .[] as $elem ([]; [$elem] + .)       # => ["D", "C", "B", "A"]
   ```
 
-[jq-man-reduce]: https://stedolan.github.io/jq/manual/v1.6/#Reduce
+[jq-man-reduce]: https://jqlang.github.io/jq/manual/v1.6/#Reduce
 
-[jq-man-iterator]: https://stedolan.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]
+[jq-man-iterator]: https://jqlang.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]

--- a/concepts/reduce/links.json
+++ b/concepts/reduce/links.json
@@ -4,7 +4,7 @@
     "description": "Fold, on Wikipedia"
   },
   {
-    "url": "https://github.com/stedolan/jq/wiki/jq-Language-Description#reductions",
+    "url": "https://github.com/jqlang/jq/wiki/jq-Language-Description#reductions",
     "description": "Reductions, in jq wiki"
   }
 ]

--- a/concepts/regular-expressions/about.md
+++ b/concepts/regular-expressions/about.md
@@ -246,5 +246,5 @@ For example
 
 [oniguruma]: https://github.com/kkos/oniguruma
 [onig-syntax]: https://github.com/kkos/oniguruma/blob/6fa38f4084b448592888ed9ee43c6e90a46b5f5c/doc/RE
-[jq-regex-funcs]: https://stedolan.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
-[jq-interp]: https://stedolan.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[jq-regex-funcs]: https://jqlang.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
+[jq-interp]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)

--- a/concepts/regular-expressions/introduction.md
+++ b/concepts/regular-expressions/introduction.md
@@ -224,5 +224,5 @@ For example
 
 [oniguruma]: https://github.com/kkos/oniguruma
 [onig-syntax]: https://github.com/kkos/oniguruma/blob/6fa38f4084b448592888ed9ee43c6e90a46b5f5c/doc/RE
-[jq-regex-funcs]: https://stedolan.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
-[jq-interp]: https://stedolan.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[jq-regex-funcs]: https://jqlang.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
+[jq-interp]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)

--- a/concepts/regular-expressions/links.json
+++ b/concepts/regular-expressions/links.json
@@ -4,7 +4,7 @@
     "description": "Oniguruma regular expression syntax"
   },
   {
-    "url": "https://github.com/stedolan/jq/wiki/FAQ#support-for-regular-expressions",
+    "url": "https://github.com/jqlang/jq/wiki/FAQ#support-for-regular-expressions",
     "description": "jq regex FAQ"
   }
 ]

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -160,22 +160,22 @@ Check [the manual][manual] for more details about these functions:
 
 `jq` has rich support for regular expressions: this will be the topic of a later lesson.
 
-[manual]: https://stedolan.github.io/jq/manual/v1.6/
-[interpolate]: https://stedolan.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
-[length]: https://stedolan.github.io/jq/manual/v1.6/#length
-[utf8bytelength]: https://stedolan.github.io/jq/manual/v1.6/#utf8bytelength
-[+]: https://stedolan.github.io/jq/manual/v1.6/#Addition:+
-[/]: https://stedolan.github.io/jq/manual/v1.6/#Multiplication,division,modulo:*,/,and%
-[add]: https://stedolan.github.io/jq/manual/v1.6/#add
-[split/1]: https://stedolan.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
-[join/1]: https://stedolan.github.io/jq/manual/v1.6/#join(str)
-[explode]: https://stedolan.github.io/jq/manual/v1.6/#explode
-[implode]: https://stedolan.github.io/jq/manual/v1.6/#implode
-[ascii_downcase]: https://stedolan.github.io/jq/manual/v1.6/#ascii_downcase,ascii_upcase
-[tonumber]: https://stedolan.github.io/jq/manual/v1.6/#tonumber
-[try-catch]: https://stedolan.github.io/jq/manual/v1.6/#try-catch
+[manual]: https://jqlang.github.io/jq/manual/v1.6/
+[interpolate]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[length]: https://jqlang.github.io/jq/manual/v1.6/#length
+[utf8bytelength]: https://jqlang.github.io/jq/manual/v1.6/#utf8bytelength
+[+]: https://jqlang.github.io/jq/manual/v1.6/#Addition:+
+[/]: https://jqlang.github.io/jq/manual/v1.6/#Multiplication,division,modulo:*,/,and%
+[add]: https://jqlang.github.io/jq/manual/v1.6/#add
+[split/1]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[join/1]: https://jqlang.github.io/jq/manual/v1.6/#join(str)
+[explode]: https://jqlang.github.io/jq/manual/v1.6/#explode
+[implode]: https://jqlang.github.io/jq/manual/v1.6/#implode
+[ascii_downcase]: https://jqlang.github.io/jq/manual/v1.6/#ascii_downcase,ascii_upcase
+[tonumber]: https://jqlang.github.io/jq/manual/v1.6/#tonumber
+[try-catch]: https://jqlang.github.io/jq/manual/v1.6/#try-catch
 [json-numbers]: https://www.json.org/json-en.html
-[indices]: https://stedolan.github.io/jq/manual/v1.6/#indices(s)
-[index/1]: https://stedolan.github.io/jq/manual/v1.6/#index(s),rindex(s)
+[indices]: https://jqlang.github.io/jq/manual/v1.6/#indices(s)
+[index/1]: https://jqlang.github.io/jq/manual/v1.6/#index(s),rindex(s)
 
-[slice]: https://stedolan.github.io/jq/manual/v1.6/#Array/StringSlice:.[10:15]
+[slice]: https://jqlang.github.io/jq/manual/v1.6/#Array/StringSlice:.[10:15]

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -116,4 +116,4 @@ Use the `ascii_downcase` and `ascii_upcase` functions.
 
 `jq` has rich support for regular expressions: this will be the topic of a later lesson.
 
-[interpolate]: https://stedolan.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[interpolate]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)

--- a/concepts/strings/links.json
+++ b/concepts/strings/links.json
@@ -1,14 +1,14 @@
 [
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#TypesandValues",
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#TypesandValues",
     "description": "Types and Values"
   },
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)",
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)",
     "description": "String interpolation"
   },
   {
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#Formatstringsandescaping",
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#Formatstringsandescaping",
     "description": "Format strings and escaping"
   }
 ]

--- a/concepts/variables/links.json
+++ b/concepts/variables/links.json
@@ -1,6 +1,6 @@
 [
   {
     "description": "Assignment",
-    "url": "https://stedolan.github.io/jq/manual/v1.6/#Assignment"
+    "url": "https://jqlang.github.io/jq/manual/v1.6/#Assignment"
   }
 ]

--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
     "highlightjs_language": "jq"
   },
   "test_runner": {
-    "average_run_time": 54
+    "average_run_time": 20
   },
   "files": {
     "solution": [

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -46,9 +46,9 @@ We will assume you are familiar with [JSON syntax and data types][wiki-json].
 - [`jq` wiki][jq-wiki]
 - [Stack Overflow jq info page][so]
 
-[jq]: https://stedolan.github.io/jq/
-[jq-wiki]: https://github.com/stedolan/jq/wiki
+[jq]: https://jqlang.github.io/jq/
+[jq-wiki]: https://github.com/jqlang/jq/wiki
 [so]: https://stackoverflow.com/tags/jq/info
 [json]: https://www.json.org
 [wiki-json]: https://en.wikipedia.org/wiki/JSON#Syntax
-[cli-options]: https://stedolan.github.io/jq/manual/v1.6/#Invokingjq
+[cli-options]: https://jqlang.github.io/jq/manual/v1.6/#Invokingjq

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,4 +2,4 @@
 
 Please head to [the `jq` wiki][jq-wiki-install] for the installation instructions.
 
-[jq-wiki-install]: https://github.com/stedolan/jq/wiki/Installation
+[jq-wiki-install]: https://github.com/jqlang/jq/wiki/Installation

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,6 +1,6 @@
 # Learning
 
-- [`jq` Tutorial](https://stedolan.github.io/jq/tutorial/)
+- [`jq` Tutorial](https://jqlang.github.io/jq/tutorial/)
 - [Guide to Linux jq Command for JSON Processing](https://www.baeldung.com/linux/jq-command-json)
 - [Illustrated jq tutorial](https://mosermichael.github.io/jq-illustrated/dir/content.html)
 - [An Introduction to JQ](https://earthly.dev/blog/jq-select/)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -19,9 +19,9 @@
 - [jo][jo]: A small utility to create JSON objects from shell variables.
 - [jello][jello]: jello is similar to jq except jello uses standard python dict and list syntax.
 
-[jq]: https://stedolan.github.io/jq
-[github]: https://github.com/stedolan/jq
-[wiki]: https://github.com/stedolan/jq/wiki
+[jq]: https://jqlang.github.io/jq
+[github]: https://github.com/jqlang/jq
+[wiki]: https://github.com/jqlang/jq/wiki
 [jqplay]: https://jqplay.org
 [ijq]: https://github.com/gpanders/ijq
 [gron]: https://github.com/tomnomnom/gron#readme

--- a/exercises/concept/assembly-line/.docs/hints.md
+++ b/exercises/concept/assembly-line/.docs/hints.md
@@ -18,7 +18,7 @@
 - Division uses the `/` operator.
 - The result of the division will need to be truncated with [the `trunc` function][math-funcs].
 
-[eq]: https://stedolan.github.io/jq/manual/v1.6/#==,!=
-[cmp]: https://stedolan.github.io/jq/manual/v1.6/#%3E,%3E=,%3C=,%3C
-[if-then-else]: https://stedolan.github.io/jq/manual/v1.6/#if-then-else
-[math-funcs]: https://stedolan.github.io/jq/manual/v1.6/#Math
+[eq]: https://jqlang.github.io/jq/manual/v1.6/#==,!=
+[cmp]: https://jqlang.github.io/jq/manual/v1.6/#%3E,%3E=,%3C=,%3C
+[if-then-else]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else
+[math-funcs]: https://jqlang.github.io/jq/manual/v1.6/#Math

--- a/exercises/concept/assembly-line/.docs/introduction.md
+++ b/exercises/concept/assembly-line/.docs/introduction.md
@@ -63,6 +63,6 @@ Additional conditions use `elif`
 # => "medium"
 ```
 
-[man-types]: https://stedolan.github.io/jq/manual/v1.6/#TypesandValues
-[man-math]: https://stedolan.github.io/jq/manual/v1.6/#Math
-[if-then-else]: https://stedolan.github.io/jq/manual/v1.6/#if-then-else
+[man-types]: https://jqlang.github.io/jq/manual/v1.6/#TypesandValues
+[man-math]: https://jqlang.github.io/jq/manual/v1.6/#Math
+[if-then-else]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else-end

--- a/exercises/concept/bird-count/.docs/hints.md
+++ b/exercises/concept/bird-count/.docs/hints.md
@@ -24,5 +24,5 @@
 
 - The one-argument version of the [any][manual-any] filter will be appropriate.
 
-[manual-add]: https://stedolan.github.io/jq/manual/v1.6/#add
-[manual-any]: https://stedolan.github.io/jq/manual/v1.6/#all,all(condition),all(generator;condition)
+[manual-add]: https://jqlang.github.io/jq/manual/v1.6/#add
+[manual-any]: https://jqlang.github.io/jq/manual/v1.6/#all,all(condition),all(generator;condition)

--- a/exercises/concept/grade-stats/.docs/hints.md
+++ b/exercises/concept/grade-stats/.docs/hints.md
@@ -12,5 +12,5 @@
 - The result object must have all the possible letter grades as keys, even if no students earned that grade.
 - The [`+=` assignment][jq-man-arith-assign] will be useful.
 
-[jq-man-if]: https://stedolan.github.io/jq/manual/v1.6/#if-then-else
-[jq-man-arith-assign]: https://stedolan.github.io/jq/manual/v1.6/#Arithmeticupdate-assignment:+=,-=,*=,/=,%=,//=
+[jq-man-if]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else
+[jq-man-arith-assign]: https://jqlang.github.io/jq/manual/v1.6/#Arithmeticupdate-assignment:+=,-=,*=,/=,%=,//=

--- a/exercises/concept/grade-stats/.docs/introduction.md
+++ b/exercises/concept/grade-stats/.docs/introduction.md
@@ -73,7 +73,7 @@ The `add` builtin is actually [implemented with `reduce`][jq-code-add], but uses
 def add: reduce .[] as $x (null; . + $x);
 ```
 
-[jq-code-add]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L11
+[jq-code-add]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L11
 ~~~~
 
 <!-- prettier-ignore-end -->
@@ -97,5 +97,5 @@ def add: reduce .[] as $x (null; . + $x);
   | reduce .[] as $elem ([]; [$elem] + .)       # => ["D", "C", "B", "A"]
   ```
 
-[jq-man-reduce]: https://stedolan.github.io/jq/manual/v1.6/#Reduce
-[jq-man-iterator]: https://stedolan.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]
+[jq-man-reduce]: https://jqlang.github.io/jq/manual/v1.6/#Reduce
+[jq-man-iterator]: https://jqlang.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]

--- a/exercises/concept/high-score-board/.docs/hints.md
+++ b/exercises/concept/high-score-board/.docs/hints.md
@@ -36,9 +36,9 @@
   We can use [`map_values`][man-map_values], or [`.[]`][man-brackets] to output a stream of values.
 - The `add` expression can be used to find the sum of a list of numbers.
 
-[man-plus]: https://stedolan.github.io/jq/manual/v1.6/#Addition:+
-[man-del]: https://stedolan.github.io/jq/manual/v1.6/#del(path_expression)
-[man-update-assignment]: https://stedolan.github.io/jq/manual/v1.6/#Arithmeticupdate-assignment:+=,-=,*=,/=,%=,//=
-[man-map_values]: https://stedolan.github.io/jq/manual/v1.6/#map(x),map_values(x)
+[man-plus]: https://jqlang.github.io/jq/manual/v1.6/#Addition:+
+[man-del]: https://jqlang.github.io/jq/manual/v1.6/#del(path_expression)
+[man-update-assignment]: https://jqlang.github.io/jq/manual/v1.6/#Arithmeticupdate-assignment:+=,-=,*=,/=,%=,//=
+[man-map_values]: https://jqlang.github.io/jq/manual/v1.6/#map(x),map_values(x)
 
-[man-brackets]: https://stedolan.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]
+[man-brackets]: https://jqlang.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]

--- a/exercises/concept/lasagna/.docs/hints.md
+++ b/exercises/concept/lasagna/.docs/hints.md
@@ -28,7 +28,7 @@
 - Include the calculated value in the output object for the key `"total_time"`.
 - [The `+` operator][addition] is used for arithmetic addition on numbers.
 
-[subtraction]: https://stedolan.github.io/jq/manual/v1.6/#Subtraction:-
-[multiplication]: https://stedolan.github.io/jq/manual/v1.6/#Multiplication,division,modulo:*,/,and%
-[addition]: https://stedolan.github.io/jq/manual/v1.6/#Addition:+
-[alternative]: https://stedolan.github.io/jq/manual/v1.6/#Alternativeoperator://
+[subtraction]: https://jqlang.github.io/jq/manual/v1.6/#Subtraction:-
+[multiplication]: https://jqlang.github.io/jq/manual/v1.6/#Multiplication,division,modulo:*,/,and%
+[addition]: https://jqlang.github.io/jq/manual/v1.6/#Addition:+
+[alternative]: https://jqlang.github.io/jq/manual/v1.6/#Alternativeoperator://

--- a/exercises/concept/log-line-parser/.docs/introduction.md
+++ b/exercises/concept/log-line-parser/.docs/introduction.md
@@ -118,4 +118,4 @@ Use the `ascii_downcase` and `ascii_upcase` functions.
 
 `jq` has rich support for regular expressions: this will be the topic of a later lesson.
 
-[interpolate]: https://stedolan.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[interpolate]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)

--- a/exercises/concept/recursive-functions/.docs/hints.md
+++ b/exercises/concept/recursive-functions/.docs/hints.md
@@ -27,4 +27,4 @@
 - The base case is an empty array.
 
 [arrays-concept]: /tracks/jq/concepts/arrays
-[manual-addition]: https://stedolan.github.io/jq/manual/v1.6/#Addition:+
+[manual-addition]: https://jqlang.github.io/jq/manual/v1.6/#Addition:+

--- a/exercises/concept/recursive-functions/.docs/introduction.md
+++ b/exercises/concept/recursive-functions/.docs/introduction.md
@@ -58,6 +58,6 @@ In practice, iterating over lists and other enumerable data structures is most o
 such as `map` and `reduce`, or by [using streams][map-implementation] like `[.[] | select(...)]`.
 Under the hood, some builtins are [implemented using recursion][range-implementation].
 
-[map-implementation]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L3
-[range-implementation]: https://github.com/stedolan/jq/blob/jq-1.6/src/builtin.jq#L157
+[map-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L3
+[range-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L157
 [wiki-fibonacci]: https://en.wikipedia.org/wiki/Fibonacci_number

--- a/exercises/concept/regular-chatbot/.docs/hints.md
+++ b/exercises/concept/regular-chatbot/.docs/hints.md
@@ -34,12 +34,12 @@
 - The pattern is "comma followed by zero or more whitespace".
 - We have to use the **2-arity** `split` filter; there are no flags that need to be specified.
 
-[flags]: https://stedolan.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
-[regex-test]: https://stedolan.github.io/jq/manual/v1.6/#test(val),test(regex;flags)
-[regex-gsub]: https://stedolan.github.io/jq/manual/v1.6/#gsub(regex;string),gsub(regex;string;flags)
-[regex-match]: https://stedolan.github.io/jq/manual/v1.6/#match(val),match(regex;flags)
-[regex-scan]: https://stedolan.github.io/jq/manual/v1.6/#scan(regex),scan(regex;flags)
-[regex-split]: https://stedolan.github.io/jq/manual/v1.6/#split(regex;flags)
-[regex-capture]: https://stedolan.github.io/jq/manual/v1.6/#capture(val),capture(regex;flags)
+[flags]: https://jqlang.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
+[regex-test]: https://jqlang.github.io/jq/manual/v1.6/#test(val),test(regex;flags)
+[regex-gsub]: https://jqlang.github.io/jq/manual/v1.6/#gsub(regex;string),gsub(regex;string;flags)
+[regex-match]: https://jqlang.github.io/jq/manual/v1.6/#match(val),match(regex;flags)
+[regex-scan]: https://jqlang.github.io/jq/manual/v1.6/#scan(regex),scan(regex;flags)
+[regex-split]: https://jqlang.github.io/jq/manual/v1.6/#split(regex;flags)
+[regex-capture]: https://jqlang.github.io/jq/manual/v1.6/#capture(val),capture(regex;flags)
 [named-capture]: https://riptutorial.com/regex/example/2479/named-capture-groups
 [phone-validation]: https://www.w3resource.com/javascript/form/phone-no-validation.php

--- a/exercises/concept/regular-chatbot/.docs/introduction.md
+++ b/exercises/concept/regular-chatbot/.docs/introduction.md
@@ -226,5 +226,5 @@ For example
 
 [oniguruma]: https://github.com/kkos/oniguruma
 [onig-syntax]: https://github.com/kkos/oniguruma/blob/6fa38f4084b448592888ed9ee43c6e90a46b5f5c/doc/RE
-[jq-regex-funcs]: https://stedolan.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
-[jq-interp]: https://stedolan.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[jq-regex-funcs]: https://jqlang.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
+[jq-interp]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)

--- a/exercises/concept/remote-control-car/.docs/hints.md
+++ b/exercises/concept/remote-control-car/.docs/hints.md
@@ -24,6 +24,6 @@
 
 - If the battery is dead, it should return the object unchanged.
 
-[string-interpolation]: https://stedolan.github.io/jq/manual/#Stringinterpolation-%5C(foo)
-[if-then-else]: https://stedolan.github.io/jq/manual/#if-then-else
-[update-assn]: https://stedolan.github.io/jq/manual/#Arithmeticupdate-assignment:+=,-=,*=,/=,%=,//=
+[string-interpolation]: https://jqlang.github.io/jq/manual/#Stringinterpolation-%5C(foo)
+[if-then-else]: https://jqlang.github.io/jq/manual/#if-then-else
+[update-assn]: https://jqlang.github.io/jq/manual/#Arithmeticupdate-assignment:+=,-=,*=,/=,%=,//=

--- a/exercises/concept/remote-control-car/.docs/introduction.md
+++ b/exercises/concept/remote-control-car/.docs/introduction.md
@@ -155,6 +155,6 @@ def my_map(func):
 A `jq` module is a file containing only functions.
 Modules are included into a jq program with the [`include`][man-include] or [`import`][man-import] commands.
 
-[man-range]: https://stedolan.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
-[man-import]: https://stedolan.github.io/jq/manual/v1.6/#importRelativePathStringasNAME[%3Cmetadata%3E];
-[man-include]: https://stedolan.github.io/jq/manual/v1.6/#includeRelativePathString[%3Cmetadata%3E];
+[man-range]: https://jqlang.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
+[man-import]: https://jqlang.github.io/jq/manual/v1.6/#importRelativePathStringasNAME[%3Cmetadata%3E];
+[man-include]: https://jqlang.github.io/jq/manual/v1.6/#includeRelativePathString[%3Cmetadata%3E];

--- a/exercises/concept/vehicle-purchase/.docs/hints.md
+++ b/exercises/concept/vehicle-purchase/.docs/hints.md
@@ -20,7 +20,7 @@
 - To calculate the result, apply the percentage to the original price.
   For example, `30% of x` can be calculated by multiplying `x` by `30` and dividing by `100`.
 
-[equality operator]: https://stedolan.github.io/jq/manual/v1.6/#==,!=
-[boolean operators]: https://stedolan.github.io/jq/manual/v1.6/#and/or/not
-[comparison operator]: https://stedolan.github.io/jq/manual/v1.6/#%3E,%3E=,%3C=,%3C
-[conditional expression]: https://stedolan.github.io/jq/manual/v1.6/#if-then-else
+[equality operator]: https://jqlang.github.io/jq/manual/v1.6/#==,!=
+[boolean operators]: https://jqlang.github.io/jq/manual/v1.6/#and/or/not
+[comparison operator]: https://jqlang.github.io/jq/manual/v1.6/#%3E,%3E=,%3C=,%3C
+[conditional expression]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else

--- a/exercises/practice/atbash-cipher/.meta/example.jq
+++ b/exercises/practice/atbash-cipher/.meta/example.jq
@@ -8,7 +8,7 @@ def mapping:
     ( range(10)
       | tostring
       | {(.): .}
-    ) 
+    )
   ] | add;
 
 def grouped: [scan(".{1,5}")] | join(" ");
@@ -25,4 +25,4 @@ def encode($map): decode($map) | grouped;
 
 # It would be nice to have a dynamic way to dispatch there.
 # There isn't one: functions are "second-class" in jq.
-# See https://github.com/stedolan/jq/wiki/jq-Language-Description#The-jq-Language
+# See https://github.com/jqlang/jq/wiki/jq-language-description#the-jq-language

--- a/exercises/practice/etl/.docs/instructions.append.md
+++ b/exercises/practice/etl/.docs/instructions.append.md
@@ -46,4 +46,4 @@ outputs
 ]
 ```
 
-[x_entries]: https://stedolan.github.io/jq/manual/v1.6/#to_entries,from_entries,with_entries
+[x_entries]: https://jqlang.github.io/jq/manual/v1.6/#to_entries,from_entries,with_entries

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -3,4 +3,4 @@
 To solve this exercise in jq, you will need to use the [builtin datetime functions][date-funcs].
 jq can only parse datetime strings in full ISO8601 format, such as `1970-01-01T00:00:00Z`
 
-[date-funcs]: https://stedolan.github.io/jq/manual/v1.6/#Dates 
+[date-funcs]: https://jqlang.github.io/jq/manual/v1.6/#Dates 

--- a/exercises/practice/nth-prime/.docs/instructions.append.md
+++ b/exercises/practice/nth-prime/.docs/instructions.append.md
@@ -12,4 +12,4 @@ In your solution, use `$n` as the input to get the nth prime.
 
 See [Invoking jq][man-invoke] in the manual.
 
-[man-invoke]: https://stedolan.github.io/jq/manual/v1.6/#Invokingjq
+[man-invoke]: https://jqlang.github.io/jq/manual/v1.6/#Invokingjq

--- a/exercises/practice/raindrops/.docs/instructions.append.md
+++ b/exercises/practice/raindrops/.docs/instructions.append.md
@@ -41,4 +41,4 @@ jq: error: Possibly unterminated 'if' statement at <top-level>, line 2:
 jq: 2 compile errors
 ```
 
-[if]: https://stedolan.github.io/jq/manual/v1.6/#if-then-else
+[if]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else-end

--- a/exercises/practice/rna-transcription/.docs/instructions.append.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.append.md
@@ -7,4 +7,4 @@ This function will expect a DNA sequence (as a string) as input, and will output
 
 Refer to [Defining Functions][def] in the jq manual.
 
-[def]: https://stedolan.github.io/jq/manual/#DefiningFunctions
+[def]: https://jqlang.github.io/jq/manual/#DefiningFunctions

--- a/exercises/practice/two-bucket/.meta/example.jq
+++ b/exercises/practice/two-bucket/.meta/example.jq
@@ -23,7 +23,7 @@ def validate:
 def solve($goal):
 
   # tail-call optimization only applies for 0-arity functions.
-  # https://github.com/stedolan/jq/wiki/Advanced-Topics#recursion-and-tail-recursion-optimization
+  # https://github.com/jqlang/jq/wiki/Advanced-Topics#recursion-and-tail-recursion-optimization
   # input to inner function is: [firstBucket, secondBucket, currentMove]
   def _solve:
     if .[0].amount == $goal

--- a/exercises/practice/two-fer/two-fer.jq
+++ b/exercises/practice/two-fer/two-fer.jq
@@ -1,9 +1,9 @@
 # You might want to look at:
 #
 # - the alternative operator:
-#   https://stedolan.github.io/jq/manual/v1.6/#Alternativeoperator://
+#   https://jqlang.github.io/jq/manual/v1.6/#Alternativeoperator://
 #
 # - string interpolation:
-#   https://stedolan.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+#   https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
 
 "Remove this line and implement your solution" | halt_error


### PR DESCRIPTION
this preserves the anchors to the correct headings which are lost in the gh redirects before the change

## Summary

(Explain what this change is attempting to accomplish)


## Checklist
- [ ] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
