### PR TITLE
Update knapsack description

### DIFF
--- a/exercises/practice/knapsack/.docs/instructions.md
+++ b/exercises/practice/knapsack/.docs/instructions.md
@@ -13,18 +13,21 @@ Given a knapsack with a specific carrying capacity (W), help Bob determine the m
 Note that Bob can take only one of each item.
 
 All values given will be strictly positive.
-Items will be represented as a list of pairs, `wi` and `vi`, where the first element `wi` is the weight of the *i*th item and `vi` is the value for that item.
+Items will be represented as an array of objects, with separate members for weight and value each.
 
 For example:
 
-Items: [
-  { "weight": 5, "value": 10 },
-  { "weight": 4, "value": 40 },
-  { "weight": 6, "value": 30 },
-  { "weight": 4, "value": 50 }
-]
-
-Knapsack Limit: 10
+```json
+{
+  "maximumWeight": 10,
+  "items": [
+    { "weight": 5, "value": 10 },
+    { "weight": 4, "value": 40 },
+    { "weight": 6, "value": 30 },
+    { "weight": 4, "value": 50 }
+  ]
+}
+```
 
 For the above, the first item has weight 5 and value 10, the second item has weight 4 and value 40, and so on.
 


### PR DESCRIPTION
## Summary

The knapsack description, which seems to look the same for many languages, has an input description that looks JSON-esque, but without newlines, resulting in

![image](https://github.com/exercism/jq/assets/8521043/25104168-7b4b-48e0-838e-6577a02d8e1b)

The description also references `wi` and `vi`, but they don't appear in the input.

This PR changes the input format to a JSON object, as actually used in the tests.

## Checklist
- [x] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green

Notice that `configlet` actually generates a diff, but it is unrelated to my change:

```diff
diff --git a/exercises/concept/assembly-line/.docs/introduction.md b/exercises/concept/assembly-line/.docs/introduction.md
index 16c6019..01b0d64 100644
--- a/exercises/concept/assembly-line/.docs/introduction.md
+++ b/exercises/concept/assembly-line/.docs/introduction.md
@@ -65,4 +65,4 @@ Additional conditions use `elif`
 
 [man-types]: https://jqlang.github.io/jq/manual/v1.6/#TypesandValues
 [man-math]: https://jqlang.github.io/jq/manual/v1.6/#Math
-[if-then-else]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else-end
+[if-then-else]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else
```