### PR TITLE
Fix links to jq manual

### DIFF
--- a/exercises/practice/two-fer/two-fer.jq
+++ b/exercises/practice/two-fer/two-fer.jq
@@ -1,9 +1,9 @@
 # You might want to look at:
 #
 # - the alternative operator:
-#   https://jqlang.github.io/jq/manual/v1.6/#Alternativeoperator://
+#   https://jqlang.github.io/jq/manual/v1.6/#alternative-operator
 #
 # - string interpolation:
-#   https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+#   https://jqlang.github.io/jq/manual/v1.6/#string-interpolation
 
 "Remove this line and implement your solution" | halt_error


### PR DESCRIPTION
## Summary
The links currently don’t work. With this fix, they should be good (for now).

## Checklist
- [ ] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
