### PR TITLE
Add task numbers to headings in concept exercises

### DIFF
--- a/exercises/concept/grade-stats/.docs/hints.md
+++ b/exercises/concept/grade-stats/.docs/hints.md
@@ -1,10 +1,10 @@
 # Hints
 
-## Translate a numeric grade to a letter grade
+## 1. Translate a numeric grade to a letter grade
 
 - Use an [`if-then-else` expression][jq-man-if] with as many `elif` branches as needed.
 
-## Count the number of students for each letter grade
+## 2. Count the number of students for each letter grade
 
 - The `reduce` filter needs a _stream_ to iterate over.
   The input is an object.

--- a/exercises/concept/grade-stats/.docs/instructions.md
+++ b/exercises/concept/grade-stats/.docs/instructions.md
@@ -4,7 +4,7 @@ You are a teacher.
 At the end of the year, you have generated a numeric grade for each of your students.
 Now you need to translate that to a letter grade and count how many students have achieved each letter grade
 
-## Translate a numeric grade to a letter grade
+## 1. Translate a numeric grade to a letter grade
 
 The `letter_grade` function will take a numeric grade as input, and it will output the letter.
 Use these ranges:
@@ -23,7 +23,7 @@ Example:
 75 | letter_grade   # => "C"
 ```
 
-## Count the number of students for each letter grade
+## 2. Count the number of students for each letter grade
 
 The function `count_letter_grades` will take an object mapping student names to their grades.
 The output will be an object mapping each letter grade to the number of students with that grade.

--- a/exercises/concept/regular-chatbot/.docs/instructions.md
+++ b/exercises/concept/regular-chatbot/.docs/instructions.md
@@ -5,7 +5,7 @@ You have been hired as a Regular Expression Specialist in a company that is deve
 It is in a very basic phase of development.
 Your mission is to use Regular Expressions to improve the Chatbot's ability to understand and generate natural language.
 
-## Check Valid Command
+## 1. Check Valid Command
 
 Apart from being smart, the Chatbot is also a loyal assistant.
 To ask the Chatbot something, the user must say the word "**Chatbot**" in the first position of the command.
@@ -23,7 +23,7 @@ Implement the function `is_valid_command` that helps the Chatbot recognize when 
 # => true
 ```
 
-## Remove Encrypted Emojis
+## 2. Remove Encrypted Emojis
 
 The Chatbot has a difficult time understanding how humans use emojis to express their emotions.
 When the Chatbot receives user messages, each emoji is represented as the string "emoji" followed by an _id number_.
@@ -39,7 +39,7 @@ Do not adjust the whitespace.
 # => "I love playing videogames  it's one of my hobbies"
 ```
 
-## Check Valid Phone Number
+## 3. Check Valid Phone Number
 
 At some point in the interaction with the Chatbot, the user will provide a phone number.
 The Chatbot can only call a number with a specific format.
@@ -58,7 +58,7 @@ The expected format is `(+NN) NNN-NNN-NNN`, where N is a digit.
 # => "Oops, it seems like I can't reach out to 659-771-594."
 ```
 
-## Get Website Link
+## 4. Get Website Link
 
 The Chatbot is a really curious software.
 Even though it can search the internet for a particular topic, it likes to ask users about cool websites to visit to find relevant information.
@@ -76,7 +76,7 @@ Implement the function `get_domains` which returns an array of website domains.
 # => ["exercism.org", "google.com"]
 ```
 
-## Greet the User
+## 5. Greet the User
 
 A polite Chatbot will speak to users by name.
 When a user introduces themselves, our Chatbot will detect their name and respond with a friendly greeting.
@@ -90,7 +90,7 @@ If the input string contains "My name is Someone.", capture the name and return 
 # => "Nice to meet you, Jean-Luc"
 ```
 
-## Very Simple CSV Parsing
+## 6. Very Simple CSV Parsing
 
 Yielding to "creeping featuritis", we'll add a CSV parsing function to the Chatbot.
 


### PR DESCRIPTION
## Summary

For the hints to be displayed correctly in the online editor the headings in the `instructions.md` and `hints.md` must match.  
That is not the case for `regular-chatbot`.
Also, currently most but not all concept exercises include the task number.

This PR adds these missing task numbers.

## Checklist
- [x] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
