### PR TITLE
Fixing incorrect uses of halt_error

### DIFF
--- a/exercises/concept/grade-stats/grade-stats.jq
+++ b/exercises/concept/grade-stats/grade-stats.jq
@@ -6,7 +6,7 @@
 # - "F" is  0% - 59%
 
 def letter_grade:
-  halt_error("Implement this function");
+  "Implement this function" | halt_error;
 
 
 # Given an object that maps a student's name to their grade,
@@ -14,4 +14,4 @@ def letter_grade:
 # students with that grade
 
 def count_letter_grades:
-  halt_error("Implement this function using reduce");
+  "Implement this function using reduce" | halt_error;

--- a/exercises/concept/high-score-board/high-score-board.jq
+++ b/exercises/concept/high-score-board/high-score-board.jq
@@ -2,34 +2,34 @@
 #   input: none.
 #   output: a score board object with a default player and score.
 def create_score_board:
-  halt_error("Please implement the create_score_board function");
+  "Please implement the create_score_board function" | halt_error;
 
 # Add a player to a score board.
 #   input: a score board object.
 #   output: the score board with the new player added.
 def add_player(player; score):
-  halt_error("Please implement the add_player function");
+  "Please implement the add_player function" | halt_error;
 
 # Remove a player from a score board.
 #   input: a score board object.
 #   output: the score board with the player removed, if they exist.
 def remove_player(player):
-  halt_error("Please implement the remove_player function");
+  "Please implement the remove_player function" | halt_error;
 
 # Increase a player's score by the given amount.
 #   input: a score board object.
 #   output: the score board with the player's score increased, if they exist.
 def update_score(player; points):
-  halt_error("Please implement the update_score function");
+  "Please implement the update_score function" | halt_error;
 
 # Apply 100 bonus points to all players on the board.
 #   input: a score board object.
 #   output: the score board with each player's score increased.
 def apply_monday_bonus:
-  halt_error("Please implement the apply_monday_bonus function");
+  "Please implement the apply_monday_bonus function" | halt_error;
 
 # Calculate the total score of all players.
 #   input: a score board object.
 #   output: the sum of all scores, or zero for an empty board.
 def total_score:
-  halt_error("Please implement the total_score function");
+  "Please implement the total_score function" | halt_error;

--- a/exercises/concept/recursive-functions/recursive-functions.jq
+++ b/exercises/concept/recursive-functions/recursive-functions.jq
@@ -4,7 +4,7 @@
 #   [1, 2, 3] | array_add           # => 6
 
 def array_add:
-  halt_error("Implement this as a recursive function.");
+  "Implement this as a recursive function." | halt_error;
 
 # Reverse the input array, and return the result in a new array.
 #
@@ -12,7 +12,7 @@ def array_add:
 #   [1, 2, 3] | array_reverse       # => [3, 2, 1]
 
 def array_reverse:
-  halt_error("Implement this as a recursive function.");
+  "Implement this as a recursive function." | halt_error;
 
 # Run the filter `f` for each element of the input array,
 # and return the outputs in a new array.
@@ -21,4 +21,4 @@ def array_reverse:
 #   [1, 2, 3] | array_map(. + 1)    # => [2, 3, 4]
 
 def array_map(f):
-  halt_error("Implement this as a recursive function.");
+  "Implement this as a recursive function." | halt_error;

--- a/exercises/concept/vehicle-purchase/vehicle-purchase.jq
+++ b/exercises/concept/vehicle-purchase/vehicle-purchase.jq
@@ -5,7 +5,7 @@
 # output: {boolean} whether a license is required
 
 def needs_license:
-  halt_error("Please implement the needsLicense function");
+  "Please implement the needsLicense function" | halt_error;
 
 # Task 2
 # Helps choosing between two options by recommending the one that
@@ -14,7 +14,7 @@ def needs_license:
 # input: {array of strings} options to consider
 # output: {string} a sentence of advice which option to choose
 def choose_vehicle:
-  halt_error("Please implement the chooseVehicle function");
+  "Please implement the chooseVehicle function" | halt_error;
 
 # Task 3
 # Calculates an estimate for the price of a used vehicle in the dealership
@@ -24,4 +24,4 @@ def choose_vehicle:
 # output: {number} expected resell price in the dealership
 
 def resell_price:
-  halt_error("Please implement the calculateResellPrice function");
+  "Please implement the calculateResellPrice function" | halt_error;


### PR DESCRIPTION
`halt_error` is a filter that takes the error message as input and optionally takes the exit status as an argument. 

Demo (with fish shell syntax)
```sh
$ jq -n 'halt_error("foo")'
jq: error (at <unknown>): null (null) halt_error/1: number required
$ jq -n '"foo" | halt_error'; printf "\n%d\n"  $status
foo
5
$ jq -n '"foo" | halt_error(2)'; printf "\n%d\n"  $status
foo
2
```

This PR fixes the concept exercise stub files where halt_error is used incorrectly.

[no important files changed]