### PR TITLE
Switch track to jq version 1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install software
-        run: sudo apt update && sudo apt -y install jq bats
+        run: |
+          sudo apt update \
+          && sudo apt -y install bats curl \
+          && sudo curl -o /usr/local/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 \
+          && sudo chmod 755 /usr/local/bin/jq
 
       - name: Run tests for all exercises
         run: bash bin/ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
 
       - name: Install software
         run: |
-          sudo apt update \
-          && sudo apt -y install bats curl \
-          && sudo curl -o /usr/local/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 \
-          && sudo chmod 755 /usr/local/bin/jq
+          sudo apt update && sudo apt -y install bats &&
+          sudo curl -L -o /usr/bin/jq  https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 &&
+          sudo chmod -v 755 /usr/bin/jq
 
       - name: Run tests for all exercises
         run: bash bin/ci

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ name: jq / pr
 on: pull_request
 
 jobs:
-  ci:
+  pr:
     runs-on: ubuntu-latest
 
     steps:
@@ -14,10 +14,9 @@ jobs:
 
       - name: Install software
         run: |
-          sudo apt update \
-          && sudo apt -y install bats curl \
-          && sudo curl -o /usr/local/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 \
-          && sudo chmod 755 /usr/local/bin/jq
+          sudo apt update && sudo apt -y install bats &&
+          sudo curl -L -o /usr/bin/jq  https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 &&
+          sudo chmod -v 755 /usr/bin/jq
 
       - name: Run tests for changed/added exercises
         env:
@@ -25,8 +24,8 @@ jobs:
         run: |
           pr_endpoint=$(jq -r '"repos/\(.repository.full_name)/pulls/\(.pull_request.number)"' "$GITHUB_EVENT_PATH")
           gh api "$pr_endpoint/files" --paginate --jq '
-            .[] |
-              select(.status | IN("added", "modified", "renamed")) |
-              select(.filename | test("\\.(jq|bats|bash)$")) |
-              .filename
+              .[]
+              | select(.status | IN("added", "modified", "renamed"))
+              | select(.filename | test("\\.(jq|bats|bash)$"))
+              | .filename
           ' | xargs -r bash bin/pr

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install software
-        run: sudo apt update && sudo apt -y install jq bats
+        run: |
+          sudo apt update \
+          && sudo apt -y install bats curl \
+          && sudo curl -o /usr/local/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 \
+          && sudo chmod 755 /usr/local/bin/jq
 
       - name: Run tests for changed/added exercises
         env:

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -379,11 +379,11 @@ Without going into great depth (functions will be a topic for another exercise),
 
 Comments start with a `#` character and continue to the end of the line.
 
-[man-cli]: https://jqlang.github.io/jq/manual/v1.6/#Invokingjq
-[man-types]: https://jqlang.github.io/jq/manual/v1.6/#TypesandValues
-[man-length]: https://jqlang.github.io/jq/manual/v1.6/#length
-[man-range]: https://jqlang.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
-[man-map]: https://jqlang.github.io/jq/manual/v1.6/#map(x),map_values(x)
-[man-plus]: https://jqlang.github.io/jq/manual/v1.6/#Addition:+
-[man-add]: https://jqlang.github.io/jq/manual/v1.6/#add
-[man-select]: https://jqlang.github.io/jq/manual/v1.6/#select(boolean_expression)
+[man-cli]: https://jqlang.github.io/jq/manual/v1.7/#invoking-jq
+[man-types]: https://jqlang.github.io/jq/manual/v1.7/#types-and-values
+[man-length]: https://jqlang.github.io/jq/manual/v1.7/#length
+[man-range]: https://jqlang.github.io/jq/manual/v1.7/#range
+[man-map]: https://jqlang.github.io/jq/manual/v1.7/#map-map_values
+[man-plus]: https://jqlang.github.io/jq/manual/v1.7/#addition
+[man-add]: https://jqlang.github.io/jq/manual/v1.7/#add
+[man-select]: https://jqlang.github.io/jq/manual/v1.7/#select

--- a/concepts/basics/links.json
+++ b/concepts/basics/links.json
@@ -4,11 +4,11 @@
     "description": "jq Program Structure and Basic Syntax"
   },
   {
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#Basicfilters",
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#basic-filters",
     "description": "Basic filters"
   },
   {
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#TypesandValues]",
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#types-and-values",
     "description": "Types and Values"
   }
 ]

--- a/concepts/compare/about.md
+++ b/concepts/compare/about.md
@@ -29,7 +29,7 @@ The comparison operators above can also be used to compare strings.
 In that case, a dictionary (lexicographical) order is applied.
 The ordering is [by unicode codepoint value][sort].
 
-[sort]: https://jqlang.github.io/jq/manual/v1.6/#sort,sort_by(path_expression)
+[sort]: https://jqlang.github.io/jq/manual/v1.7/#sort-sort_by
 
 ```jq
 "Apple" > "Pear",   # => false

--- a/concepts/compare/links.json
+++ b/concepts/compare/links.json
@@ -1,10 +1,10 @@
 [
   {
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#%3E,%3E=,%3C=,%3C",
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#%3E-%3E=-%3C=-%3C",
     "description": "Relational operators"
   },
   {
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#==,!=",
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#==-!=",
     "description": " operators"
   },
   {

--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -18,16 +18,29 @@ The input to the `if` filter will be passed to `B` or `C`.
 5 | if . % 2 == 0 then . / 2 else . * 4 end     # => 20
 ```
 
-The `else` clause is **mandatory** in the current `jq` release (version 1.6).
+~~~~exercism/note
+The `else` clause is **optional** in the current `jq` release (version 1.7):
+the following two statements are equivalent.
+
+```jq
+if A then B else . end
+if A then B end
+```
+
+The `else` clause is **mandatory** in the previous v1.6 release. 
+Omitting it produces errors.
 
 ```sh
-$ jq -n 'if 1 < 2 then "OK" end'
+$ /bin/jq --version
+jq-1.6
+$ /bin/jq -n 'if 1 < 2 then "OK" end'
 jq: error: syntax error, unexpected end (Unix shell quoting issues?) at <top-level>, line 1:
 if 1 < 2 then "OK" end
 jq: error: Possibly unterminated 'if' statement at <top-level>, line 1:
 if 1 < 2 then "OK" end
 jq: 2 compile errors
 ```
+~~~~
 
 ## Nested If-Statements
 

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -18,7 +18,17 @@ The input to the `if` filter will be passed to `B` or `C`.
 5 | if . % 2 == 0 then . / 2 else . * 4 end     # => 20
 ```
 
-The `else` clause is **mandatory** in the current `jq` release (version 1.6).
+~~~~exercism/note
+The `else` clause is **optional** in the current `jq` release (version 1.7):
+the following two statements are equivalent.
+
+```jq
+if A then B else . end
+if A then B end
+```
+
+The `else` clause is **mandatory** in the previous v1.6 release. 
+~~~~
 
 ## Nested If-Statements
 

--- a/concepts/conditionals/links.json
+++ b/concepts/conditionals/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#if-then-else",
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#if-then-else-end",
     "description": "The if-then-else expression"
   }
 ]

--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -202,7 +202,6 @@ def my_map(func):
 A `jq` module is a file containing only functions.
 Modules are included into a jq program with the [`include`][man-include] or [`import`][man-import] commands.
 
-[man-range]: https://jqlang.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
-
-[man-import]: https://jqlang.github.io/jq/manual/v1.6/#importRelativePathStringasNAME[%3Cmetadata%3E];
-[man-include]: https://jqlang.github.io/jq/manual/v1.6/#includeRelativePathString[%3Cmetadata%3E];
+[man-range]: https://jqlang.github.io/jq/manual/v1.7/#range
+[man-import]: https://jqlang.github.io/jq/manual/v1.7/#import-relativepathstring-as-name
+[man-include]: https://jqlang.github.io/jq/manual/v1.7/#include-relativepathstring

--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -153,7 +153,6 @@ def my_map(func):
 A `jq` module is a file containing only functions.
 Modules are included into a jq program with the [`include`][man-include] or [`import`][man-import] commands.
 
-[man-range]: https://jqlang.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
-
-[man-import]: https://jqlang.github.io/jq/manual/v1.6/#importRelativePathStringasNAME[%3Cmetadata%3E];
-[man-include]: https://jqlang.github.io/jq/manual/v1.6/#includeRelativePathString[%3Cmetadata%3E];
+[man-range]: https://jqlang.github.io/jq/manual/v1.7/#range
+[man-import]: https://jqlang.github.io/jq/manual/v1.7/#import-relativepathstring-as-name
+[man-include]: https://jqlang.github.io/jq/manual/v1.7/#include-relativepathstring

--- a/concepts/functions/links.json
+++ b/concepts/functions/links.json
@@ -1,7 +1,7 @@
 [
   {
     "description": "\"Defining Functions\" in the manual",
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#DefiningFunctions"
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#defining-functions"
   },
   {
     "description": "\"Advanced Topics\" in the wiki",
@@ -9,6 +9,6 @@
   },
   {
     "description": "\"Modules\" in the manual",
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#Modules"
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#modules"
   }
 ]

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -66,7 +66,7 @@ This means that `jq` is not capable of handling arbitrarily large numbers.
 As an _expression_, it is placed in a pipeline.
 
 Then syntax is: `if CONDTITION then TRUE_EXPR else FALSE_EXPR end`.
-The `else` clause is required in jq v1.6.
+The `else` clause is optional in jq v1.7, but it is required in jq v1.6.
 
 ```jq
 42 | if . < 33 then "small" else "larger" end

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -83,6 +83,6 @@ Additional conditions use `elif`
 # => "medium"
 ```
 
-[man-types]: https://jqlang.github.io/jq/manual/v1.6/#TypesandValues
-[man-math]: https://jqlang.github.io/jq/manual/v1.6/#Math
-[if-then-else]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else
+[man-types]: https://jqlang.github.io/jq/manual/v1.7/#types-and-values
+[man-math]: https://jqlang.github.io/jq/manual/v1.7/#math
+[if-then-else]: https://jqlang.github.io/jq/manual/v1.7/#if-then-else-end

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -44,7 +44,8 @@ To solve the exercise, you will need to know about conditional expressions.
 As an _expression_, it is placed in a pipeline.
 
 Then syntax is: `if CONDITION then TRUE_EXPR else FALSE_EXPR end`.
-The `else` clause is required in jq v1.6.
+
+The `else` clause is optional in jq v1.7, but it is required in jq v1.6.
 
 ```jq
 42 | if . < 33 then "small" else "larger" end

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -62,6 +62,6 @@ Additional conditions use `elif`
 # => "medium"
 ```
 
-[man-types]: https://jqlang.github.io/jq/manual/v1.6/#TypesandValues
-[man-math]: https://jqlang.github.io/jq/manual/v1.6/#Math
-[if-then-else]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else
+[man-types]: https://jqlang.github.io/jq/manual/v1.7/#types-and-values
+[man-math]: https://jqlang.github.io/jq/manual/v1.7/#math
+[if-then-else]: https://jqlang.github.io/jq/manual/v1.7/#if-then-else-end

--- a/concepts/numbers/links.json
+++ b/concepts/numbers/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#TypesandValues]",
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#types-and-values",
     "description": "Types and Values"
   },
   {

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -54,7 +54,7 @@ def count_occurrences(x):
 
 In practice, iterating over lists and other enumerable data structures is most often done using builtin functions,
 such as `map` and `reduce`, or by [using streams][map-implementation] like `[.[] | select(...)]`.
-Under the hood, some builtins are [implemented using recursion][range-implementation].
+Under the hood, some builtins are [implemented using recursion][walk-implementation].
 
 ## Infinite recursion
 
@@ -104,8 +104,8 @@ def fibonacci:
 10 | fibonacci          # => 55
 ```
 
-[map-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L3
-[range-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L157
+[map-implementation]: https://github.com/jqlang/jq/blob/jq-1.7/src/builtin.jq#L3
+[walk-implementation]: https://github.com/jqlang/jq/blob/jq-1.7/src/builtin.jq#L248
 [wiki-fibonacci]: https://en.wikipedia.org/wiki/Fibonacci_number
 [wiki-tail-call]: https://en.wikipedia.org/wiki/Tail_call
 [wiki-call-stack]: https://en.wikipedia.org/wiki/Call_stack

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -54,8 +54,8 @@ def count_occurrences(x):
 
 In practice, iterating over lists and other enumerable data structures is most often done using builtin functions,
 such as `map` and `reduce`, or by [using streams][map-implementation] like `[.[] | select(...)]`.
-Under the hood, some builtins are [implemented using recursion][range-implementation].
+Under the hood, some builtins are [implemented using recursion][walk-implementation].
 
-[map-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L3
-[range-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L157
+[map-implementation]: https://github.com/jqlang/jq/blob/jq-1.7/src/builtin.jq#L3
+[walk-implementation]: https://github.com/jqlang/jq/blob/jq-1.7/src/builtin.jq#L248
 [wiki-fibonacci]: https://en.wikipedia.org/wiki/Fibonacci_number

--- a/concepts/recursion/links.json
+++ b/concepts/recursion/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#Recursion",
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#recursion",
     "description": "Recursion in the manual"
   },
   {

--- a/concepts/reduce/about.md
+++ b/concepts/reduce/about.md
@@ -71,7 +71,7 @@ The `add` builtin is actually [implemented with `reduce`][jq-code-add], but uses
 def add: reduce .[] as $x (null; . + $x);
 ```
 
-[jq-code-add]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L11
+[jq-code-add]: https://github.com/jqlang/jq/blob/jq-1.7/src/builtin.jq#L11
 ~~~~
 
 <!-- prettier-ignore-end -->
@@ -95,6 +95,5 @@ def add: reduce .[] as $x (null; . + $x);
   | reduce .[] as $elem ([]; [$elem] + .)       # => ["D", "C", "B", "A"]
   ```
 
-[jq-man-reduce]: https://jqlang.github.io/jq/manual/v1.6/#Reduce
-
-[jq-man-iterator]: https://jqlang.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]
+[jq-man-reduce]: https://jqlang.github.io/jq/manual/v1.7/#reduce
+[jq-man-iterator]: https://jqlang.github.io/jq/manual/v1.7/#array-object-value-iterator

--- a/concepts/reduce/introduction.md
+++ b/concepts/reduce/introduction.md
@@ -71,7 +71,7 @@ The `add` builtin is actually [implemented with `reduce`][jq-code-add], but uses
 def add: reduce .[] as $x (null; . + $x);
 ```
 
-[jq-code-add]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L11
+[jq-code-add]: https://github.com/jqlang/jq/blob/jq-1.7/src/builtin.jq#L11
 ~~~~
 
 <!-- prettier-ignore-end -->
@@ -95,6 +95,5 @@ def add: reduce .[] as $x (null; . + $x);
   | reduce .[] as $elem ([]; [$elem] + .)       # => ["D", "C", "B", "A"]
   ```
 
-[jq-man-reduce]: https://jqlang.github.io/jq/manual/v1.6/#Reduce
-
-[jq-man-iterator]: https://jqlang.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]
+[jq-man-reduce]: https://jqlang.github.io/jq/manual/v1.7/#reduce
+[jq-man-iterator]: https://jqlang.github.io/jq/manual/v1.7/#array-object-value-iterator

--- a/concepts/regular-expressions/about.md
+++ b/concepts/regular-expressions/about.md
@@ -10,7 +10,7 @@ We will focus on the expressions that `jq` provides to utilize regexes.
 Different tools implement different versions of regular expressions.
 `jq` incorporates the [Oniguruma][oniguruma] regex library that is largely compatible with Perl v5.8 regexes.
 
-The specific syntax used by `jq` version 1.6 can be [found on the Oniguruma GitHub repo][onig-syntax].
+The specific syntax used by `jq` version 1.7 can be [found on the Oniguruma GitHub repo][onig-syntax].
 
 <!-- prettier-ignore -->
 ~~~~exercism/caution
@@ -245,6 +245,6 @@ For example
 ```
 
 [oniguruma]: https://github.com/kkos/oniguruma
-[onig-syntax]: https://github.com/kkos/oniguruma/blob/6fa38f4084b448592888ed9ee43c6e90a46b5f5c/doc/RE
-[jq-regex-funcs]: https://jqlang.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
-[jq-interp]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[onig-syntax]: https://github.com/kkos/oniguruma/blob/v6.9.9/doc/RE
+[jq-regex-funcs]: https://jqlang.github.io/jq/manual/v1.7/#regular-expressions
+[jq-interp]: https://jqlang.github.io/jq/manual/v1.7/#string-interpolation

--- a/concepts/regular-expressions/introduction.md
+++ b/concepts/regular-expressions/introduction.md
@@ -10,7 +10,7 @@ We will focus on the expressions that `jq` provides to utilize regexes.
 Different tools implement different versions of regular expressions.
 `jq` incorporates the [Oniguruma][oniguruma] regex library that is largely compatible with Perl v5.8 regexes.
 
-The specific syntax used by `jq` version 1.6 can be [found on the Oniguruma GitHub repo][onig-syntax].
+The specific syntax used by `jq` version 1.7 can be [found on the Oniguruma GitHub repo][onig-syntax].
 
 <!-- prettier-ignore -->
 ~~~~exercism/caution
@@ -223,6 +223,6 @@ For example
 ```
 
 [oniguruma]: https://github.com/kkos/oniguruma
-[onig-syntax]: https://github.com/kkos/oniguruma/blob/6fa38f4084b448592888ed9ee43c6e90a46b5f5c/doc/RE
-[jq-regex-funcs]: https://jqlang.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
-[jq-interp]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[onig-syntax]: https://github.com/kkos/oniguruma/blob/v6.9.9/doc/RE
+[jq-regex-funcs]: https://jqlang.github.io/jq/manual/v1.7/#regular-expressions
+[jq-interp]: https://jqlang.github.io/jq/manual/v1.7/#string-interpolation

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -160,22 +160,21 @@ Check [the manual][manual] for more details about these functions:
 
 `jq` has rich support for regular expressions: this will be the topic of a later lesson.
 
-[manual]: https://jqlang.github.io/jq/manual/v1.6/
-[interpolate]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
-[length]: https://jqlang.github.io/jq/manual/v1.6/#length
-[utf8bytelength]: https://jqlang.github.io/jq/manual/v1.6/#utf8bytelength
-[+]: https://jqlang.github.io/jq/manual/v1.6/#Addition:+
-[/]: https://jqlang.github.io/jq/manual/v1.6/#Multiplication,division,modulo:*,/,and%
-[add]: https://jqlang.github.io/jq/manual/v1.6/#add
-[split/1]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
-[join/1]: https://jqlang.github.io/jq/manual/v1.6/#join(str)
-[explode]: https://jqlang.github.io/jq/manual/v1.6/#explode
-[implode]: https://jqlang.github.io/jq/manual/v1.6/#implode
-[ascii_downcase]: https://jqlang.github.io/jq/manual/v1.6/#ascii_downcase,ascii_upcase
-[tonumber]: https://jqlang.github.io/jq/manual/v1.6/#tonumber
-[try-catch]: https://jqlang.github.io/jq/manual/v1.6/#try-catch
+[manual]: https://jqlang.github.io/jq/manual/v1.7/
+[interpolate]: https://jqlang.github.io/jq/manual/v1.7/#string-interpolation
+[length]: https://jqlang.github.io/jq/manual/v1.7/#length
+[utf8bytelength]: https://jqlang.github.io/jq/manual/v1.7/#utf8bytelength
+[+]: https://jqlang.github.io/jq/manual/v1.7/#addition
+[/]: https://jqlang.github.io/jq/manual/v1.7/#multiplication-division-modulo
+[add]: https://jqlang.github.io/jq/manual/v1.7/#add
+[split/1]: https://jqlang.github.io/jq/manual/v1.7/#split-1
+[join/1]: https://jqlang.github.io/jq/manual/v1.7/#join
+[explode]: https://jqlang.github.io/jq/manual/v1.7/#explode
+[implode]: https://jqlang.github.io/jq/manual/v1.7/#implode
+[ascii_downcase]: https://jqlang.github.io/jq/manual/v1.7/#ascii_downcase-ascii_upcase
+[tonumber]: https://jqlang.github.io/jq/manual/v1.7/#tonumber
+[try-catch]: https://jqlang.github.io/jq/manual/v1.7/#try-catch
 [json-numbers]: https://www.json.org/json-en.html
-[indices]: https://jqlang.github.io/jq/manual/v1.6/#indices(s)
-[index/1]: https://jqlang.github.io/jq/manual/v1.6/#index(s),rindex(s)
-
-[slice]: https://jqlang.github.io/jq/manual/v1.6/#Array/StringSlice:.[10:15]
+[indices]: https://jqlang.github.io/jq/manual/v1.7/#indices
+[index/1]: https://jqlang.github.io/jq/manual/v1.7/#index-rindex
+[slice]: https://jqlang.github.io/jq/manual/v1.7/#array-string-slice

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -116,4 +116,4 @@ Use the `ascii_downcase` and `ascii_upcase` functions.
 
 `jq` has rich support for regular expressions: this will be the topic of a later lesson.
 
-[interpolate]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[interpolate]: https://jqlang.github.io/jq/manual/v1.7/#string-interpolation

--- a/concepts/strings/links.json
+++ b/concepts/strings/links.json
@@ -1,14 +1,14 @@
 [
   {
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#TypesandValues",
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#types-and-values",
     "description": "Types and Values"
   },
   {
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)",
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#string-interpolation",
     "description": "String interpolation"
   },
   {
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#Formatstringsandescaping",
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#format-strings-and-escaping",
     "description": "Format strings and escaping"
   }
 ]

--- a/concepts/variables/links.json
+++ b/concepts/variables/links.json
@@ -1,6 +1,6 @@
 [
   {
     "description": "Assignment",
-    "url": "https://jqlang.github.io/jq/manual/v1.6/#Assignment"
+    "url": "https://jqlang.github.io/jq/manual/v1.7/#assignment"
   }
 ]

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -26,6 +26,11 @@ The `jq` program also implements a _language_ to enable arbitrarily complex mani
 This Exercism track will focus on the language.
 You will see usage of the `jq` program in the tests.
 
+## Versions
+
+This Exercism track will focus on the original implementation of `jq`, whose home is [https://jqlang.github.io/jq/][jq].
+Other implementations, such as [`gojq`][gojq], may have different syntax to what is documented here.
+
 ## JSON
 
 From [json.org][json]:
@@ -52,3 +57,4 @@ We will assume you are familiar with [JSON syntax and data types][wiki-json].
 [json]: https://www.json.org
 [wiki-json]: https://en.wikipedia.org/wiki/JSON#Syntax
 [cli-options]: https://jqlang.github.io/jq/manual/v1.6/#Invokingjq
+[gojq]: https://github.com/itchyny/gojq#gojq

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -56,5 +56,5 @@ We will assume you are familiar with [JSON syntax and data types][wiki-json].
 [so]: https://stackoverflow.com/tags/jq/info
 [json]: https://www.json.org
 [wiki-json]: https://en.wikipedia.org/wiki/JSON#Syntax
-[cli-options]: https://jqlang.github.io/jq/manual/v1.6/#Invokingjq
+[cli-options]: https://jqlang.github.io/jq/manual/v1.7/#invoking-jq
 [gojq]: https://github.com/itchyny/gojq#gojq

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,4 +2,9 @@
 
 Please head to [the `jq` wiki][jq-wiki-install] for the installation instructions.
 
+## Version Information
+
+As of October 2023, the current jq release is version 1.7.
+Most Linux package managers will install the previous release, verion 1.6.
+
 [jq-wiki-install]: https://github.com/jqlang/jq/wiki/Installation

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -5,6 +5,6 @@ Please head to [the `jq` wiki][jq-wiki-install] for the installation instruction
 ## Version Information
 
 As of October 2023, the current jq release is version 1.7.
-Most Linux package managers will install the previous release, verion 1.6.
+Most Linux package managers will install the previous release, version 1.6.
 
 [jq-wiki-install]: https://github.com/jqlang/jq/wiki/Installation

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -6,5 +6,8 @@ Or, download the exercises to your computer, solve them locally and then submit 
 If you want to work locally, you'll need the [`bats`][bats] program.
 Please refer to the [Testing on the Bash track][test-bash] page for the installation instructions.
 
+Your code will be tested on the Exercism jq test runner using [`jq` **version 1.7**][jq].
+
 [bats]: https://github.com/bats-core/bats-core
 [test-bash]: https://exercism.org/docs/tracks/bash/tests
+[jq]: https://jqlang.github.io/jq/manual/v1.7/

--- a/exercises/concept/assembly-line/.docs/introduction.md
+++ b/exercises/concept/assembly-line/.docs/introduction.md
@@ -64,6 +64,6 @@ Additional conditions use `elif`
 # => "medium"
 ```
 
-[man-types]: https://jqlang.github.io/jq/manual/v1.6/#TypesandValues
-[man-math]: https://jqlang.github.io/jq/manual/v1.6/#Math
-[if-then-else]: https://jqlang.github.io/jq/manual/v1.6/#if-then-else
+[man-types]: https://jqlang.github.io/jq/manual/v1.7/#types-and-values
+[man-math]: https://jqlang.github.io/jq/manual/v1.7/#math
+[if-then-else]: https://jqlang.github.io/jq/manual/v1.7/#if-then-else-end

--- a/exercises/concept/assembly-line/.docs/introduction.md
+++ b/exercises/concept/assembly-line/.docs/introduction.md
@@ -46,7 +46,8 @@ To solve the exercise, you will need to know about conditional expressions.
 As an _expression_, it is placed in a pipeline.
 
 Then syntax is: `if CONDITION then TRUE_EXPR else FALSE_EXPR end`.
-The `else` clause is required in jq v1.6.
+
+The `else` clause is optional in jq v1.7, but it is required in jq v1.6.
 
 ```jq
 42 | if . < 33 then "small" else "larger" end

--- a/exercises/concept/grade-stats/.docs/introduction.md
+++ b/exercises/concept/grade-stats/.docs/introduction.md
@@ -73,7 +73,7 @@ The `add` builtin is actually [implemented with `reduce`][jq-code-add], but uses
 def add: reduce .[] as $x (null; . + $x);
 ```
 
-[jq-code-add]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L11
+[jq-code-add]: https://github.com/jqlang/jq/blob/jq-1.7/src/builtin.jq#L11
 ~~~~
 
 <!-- prettier-ignore-end -->
@@ -97,5 +97,5 @@ def add: reduce .[] as $x (null; . + $x);
   | reduce .[] as $elem ([]; [$elem] + .)       # => ["D", "C", "B", "A"]
   ```
 
-[jq-man-reduce]: https://jqlang.github.io/jq/manual/v1.6/#Reduce
-[jq-man-iterator]: https://jqlang.github.io/jq/manual/v1.6/#Array/ObjectValueIterator:.[]
+[jq-man-reduce]: https://jqlang.github.io/jq/manual/v1.7/#reduce
+[jq-man-iterator]: https://jqlang.github.io/jq/manual/v1.7/#array-object-value-iterator

--- a/exercises/concept/log-line-parser/.docs/introduction.md
+++ b/exercises/concept/log-line-parser/.docs/introduction.md
@@ -118,4 +118,4 @@ Use the `ascii_downcase` and `ascii_upcase` functions.
 
 `jq` has rich support for regular expressions: this will be the topic of a later lesson.
 
-[interpolate]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[interpolate]: https://jqlang.github.io/jq/manual/v1.7/#string-interpolation

--- a/exercises/concept/recursive-functions/.docs/introduction.md
+++ b/exercises/concept/recursive-functions/.docs/introduction.md
@@ -56,8 +56,8 @@ def count_occurrences(x):
 
 In practice, iterating over lists and other enumerable data structures is most often done using builtin functions,
 such as `map` and `reduce`, or by [using streams][map-implementation] like `[.[] | select(...)]`.
-Under the hood, some builtins are [implemented using recursion][range-implementation].
+Under the hood, some builtins are [implemented using recursion][walk-implementation].
 
-[map-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L3
-[range-implementation]: https://github.com/jqlang/jq/blob/jq-1.6/src/builtin.jq#L157
+[map-implementation]: https://github.com/jqlang/jq/blob/jq-1.7/src/builtin.jq#L3
+[walk-implementation]: https://github.com/jqlang/jq/blob/jq-1.7/src/builtin.jq#L248
 [wiki-fibonacci]: https://en.wikipedia.org/wiki/Fibonacci_number

--- a/exercises/concept/regular-chatbot/.docs/introduction.md
+++ b/exercises/concept/regular-chatbot/.docs/introduction.md
@@ -12,7 +12,7 @@ We will focus on the expressions that `jq` provides to utilize regexes.
 Different tools implement different versions of regular expressions.
 `jq` incorporates the [Oniguruma][oniguruma] regex library that is largely compatible with Perl v5.8 regexes.
 
-The specific syntax used by `jq` version 1.6 can be [found on the Oniguruma GitHub repo][onig-syntax].
+The specific syntax used by `jq` version 1.7 can be [found on the Oniguruma GitHub repo][onig-syntax].
 
 <!-- prettier-ignore -->
 ~~~~exercism/caution
@@ -225,6 +225,6 @@ For example
 ```
 
 [oniguruma]: https://github.com/kkos/oniguruma
-[onig-syntax]: https://github.com/kkos/oniguruma/blob/6fa38f4084b448592888ed9ee43c6e90a46b5f5c/doc/RE
-[jq-regex-funcs]: https://jqlang.github.io/jq/manual/v1.6/#RegularexpressionsPCRE
-[jq-interp]: https://jqlang.github.io/jq/manual/v1.6/#Stringinterpolation-%5C(foo)
+[onig-syntax]: https://github.com/kkos/oniguruma/blob/v6.9.9/doc/RE
+[jq-regex-funcs]: https://jqlang.github.io/jq/manual/v1.7/#regular-expressions
+[jq-interp]: https://jqlang.github.io/jq/manual/v1.7/#string-interpolation

--- a/exercises/concept/remote-control-car/.docs/introduction.md
+++ b/exercises/concept/remote-control-car/.docs/introduction.md
@@ -155,6 +155,6 @@ def my_map(func):
 A `jq` module is a file containing only functions.
 Modules are included into a jq program with the [`include`][man-include] or [`import`][man-import] commands.
 
-[man-range]: https://jqlang.github.io/jq/manual/v1.6/#range(upto),range(from;upto)range(from;upto;by)
-[man-import]: https://jqlang.github.io/jq/manual/v1.6/#importRelativePathStringasNAME[%3Cmetadata%3E];
-[man-include]: https://jqlang.github.io/jq/manual/v1.6/#includeRelativePathString[%3Cmetadata%3E];
+[man-range]: https://jqlang.github.io/jq/manual/v1.7/#range
+[man-import]: https://jqlang.github.io/jq/manual/v1.7/#import-relativepathstring-as-name
+[man-include]: https://jqlang.github.io/jq/manual/v1.7/#include-relativepathstring

--- a/exercises/concept/vehicle-purchase/.docs/introduction.md
+++ b/exercises/concept/vehicle-purchase/.docs/introduction.md
@@ -100,7 +100,17 @@ The input to the `if` filter will be passed to `B` or `C`.
 5 | if . % 2 == 0 then . / 2 else . * 4 end     # => 20
 ```
 
-The `else` clause is **mandatory** in the current `jq` release (version 1.6).
+~~~~exercism/note
+The `else` clause is **optional** in the current `jq` release (version 1.7):
+the following two statements are equivalent.
+
+```jq
+if A then B else . end
+if A then B end
+```
+
+The `else` clause is **mandatory** in the previous v1.6 release. 
+~~~~
 
 ### Nested If-Statements
 

--- a/exercises/practice/two-fer/two-fer.jq
+++ b/exercises/practice/two-fer/two-fer.jq
@@ -1,9 +1,9 @@
 # You might want to look at:
 #
 # - the alternative operator:
-#   https://jqlang.github.io/jq/manual/v1.6/#alternative-operator
+#   https://jqlang.github.io/jq/manual/v1.7/#alternative-operator
 #
 # - string interpolation:
-#   https://jqlang.github.io/jq/manual/v1.6/#string-interpolation
+#   https://jqlang.github.io/jq/manual/v1.7/#string-interpolation
 
 "Remove this line and implement your solution" | halt_error


### PR DESCRIPTION
## Summary

* update documentation
* For CI, update the github workflows to download a standalone jq binary from the jqlang/jq release page (ubuntu 22.04 offerss v1.6)

## Checklist
- [x] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
