### PR TITLE
Define phone number-checker input as just the phone number

### DIFF
--- a/exercises/concept/regular-chatbot/.docs/instructions.md
+++ b/exercises/concept/regular-chatbot/.docs/instructions.md
@@ -52,9 +52,9 @@ If the number is invalid, the Chatbot informs the user that the phone number is 
 The expected format is `(+NN) NNN-NNN-NNN`, where N is a digit.
 
 ```jq
-"chatbot my phone number is (+34) 659-771-594" | check_phone_number
+"(+34) 659-771-594" | check_phone_number
 # => "Thanks! Your phone number is OK."
-"chatbot, call me at 659-771-594" | check_phone_number
+"659-771-594" | check_phone_number
 # => "Oops, it seems like I can't reach out to 659-771-594."
 ```
 

--- a/exercises/concept/regular-chatbot/regular-chatbot.jq
+++ b/exercises/concept/regular-chatbot/regular-chatbot.jq
@@ -24,7 +24,7 @@ def remove_emoji:
 # - a phone number has the form "(+NN) NNN-NNN-NNN"
 #   where N is a digit
 #
-# input: {string} number
+# input: {string} phone number
 # output: {string} the Chatbot response to the phone validation
 def check_phone_number:
   . # implement the body of this function

--- a/exercises/concept/regular-chatbot/test-regular-chatbot.bats
+++ b/exercises/concept/regular-chatbot/test-regular-chatbot.bats
@@ -88,16 +88,7 @@ END_INPUT
     run jq -Rr '
         include "regular-chatbot";
         check_phone_number
-    ' <<< 'chatbot, phone (+34) 643-876-459 please'
-    assert_success
-    assert_output 'Thanks! Your phone number is OK.'
-}
-
-@test 'recognizes a phone number with another correct format' {
-    run jq -Rr '
-        include "regular-chatbot";
-        check_phone_number
-    ' <<< '(+49) 543-928-190'
+    ' <<< '(+34) 643-876-459'
     assert_success
     assert_output 'Thanks! Your phone number is OK.'
 }
@@ -120,6 +111,16 @@ END_INPUT
     '
     assert_success
     assert_output "Oops, it seems like I can't reach out to 4355-67-274."
+}
+
+@test 'informs the user that it is yet another wrong phone number format' {
+    ## task 3
+    run jq -rn '
+        include "regular-chatbot";
+        "Chatbot, phone (+49) 543-928-190" | check_phone_number
+    '
+    assert_success
+    assert_output "Oops, it seems like I can't reach out to Chatbot, phone (+49) 543-928-190"
 }
 
 @test 'returns only the link of the website' {

--- a/exercises/concept/regular-chatbot/test-regular-chatbot.bats
+++ b/exercises/concept/regular-chatbot/test-regular-chatbot.bats
@@ -113,16 +113,6 @@ END_INPUT
     assert_output "Oops, it seems like I can't reach out to 4355-67-274."
 }
 
-@test 'informs the user that it is yet another wrong phone number format' {
-    ## task 3
-    run jq -rn '
-        include "regular-chatbot";
-        "Chatbot, phone (+49) 543-928-190" | check_phone_number
-    '
-    assert_success
-    assert_output "Oops, it seems like I can't reach out to Chatbot, phone (+49) 543-928-190"
-}
-
 @test 'returns only the link of the website' {
     ## task 4
     run jq -Rc '


### PR DESCRIPTION
## Summary

Change regular-chatbot's "check_phone_number" input definition.
Update documentation and tests to reflect that change.
Fixes #208 .


## Checklist
- [x] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
