### PR TITLE
tweaks to regex concept docs

### DIFF
--- a/concepts/regular-expressions/about.md
+++ b/concepts/regular-expressions/about.md
@@ -119,7 +119,8 @@ The `scan` filter is similar to `match` with the `"g"` flag.
 ```jq
 STRING | scan(REGEX)
 STRING | scan(REGEX; FLAGS)
-STRING | scan([REGEX, FLAGS])
+
+# note, there is no scan([REGEX, FLAGS]) version, unlike other filters
 ```
 
 `scan` will output a _stream_ of substrings.
@@ -138,6 +139,17 @@ Use the `[...]` array constructor to capture the substrings.
 "Goodbye Mars" | [ scan("[aeiou]") ]
 # => ["o", "o", "e", "a"]
 ```
+
+~~~~exercism/note
+Note that jq v1.6 does _not_ implement the 2-argument `scan` function, even though the version 1.6 manual [says it does][manual-scan-1.6]:
+
+* [version 1.7 source code][src-scan-1.7]
+* [version 1.6 source code][src-scan-1.6]
+
+[manual-scan-1.6]: https://jqlang.github.io/jq/manual/v1.6/#scan
+[src-scan-1.7]: https://github.com/jqlang/jq/blob/11c528d04d76c9b9553781aa76b073e4f40da008/src/builtin.jq#L92)
+[src-scan-1.6]: https://github.com/jqlang/jq/blob/2e01ff1fb69609540b2bdc4e62a60499f2b2fb8e/src/builtin.jq#L90)
+~~~~
 
 ### Splitting a String
 

--- a/concepts/regular-expressions/introduction.md
+++ b/concepts/regular-expressions/introduction.md
@@ -119,7 +119,6 @@ The `scan` filter is similar to `match` with the `"g"` flag.
 ```jq
 STRING | scan(REGEX)
 STRING | scan(REGEX; FLAGS)
-STRING | scan([REGEX, FLAGS])
 ```
 
 `scan` will output a _stream_ of substrings.
@@ -138,6 +137,17 @@ Use the `[...]` array constructor to capture the substrings.
 "Goodbye Mars" | [ scan("[aeiou]") ]
 # => ["o", "o", "e", "a"]
 ```
+
+~~~~exercism/note
+Note that jq v1.6 does _not_ implement the 2-argument `scan` function, even though the version 1.6 manual [says it does][manual-scan-1.6]:
+
+* [version 1.7 source code][src-scan-1.7]
+* [version 1.6 source code][src-scan-1.6]
+
+[manual-scan-1.6]: https://jqlang.github.io/jq/manual/v1.6/#scan
+[src-scan-1.7]: https://github.com/jqlang/jq/blob/11c528d04d76c9b9553781aa76b073e4f40da008/src/builtin.jq#L92)
+[src-scan-1.6]: https://github.com/jqlang/jq/blob/2e01ff1fb69609540b2bdc4e62a60499f2b2fb8e/src/builtin.jq#L90)
+~~~~
 
 ### Splitting a String
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -5,6 +5,10 @@ Please head to [the `jq` wiki][jq-wiki-install] for the installation instruction
 ## Version Information
 
 As of October 2023, the current jq release is version 1.7.
+This is the version used in the online jq test runner.
+
 Most Linux package managers will install the previous release, version 1.6.
+It's worth installing the newer version: there were [substantial changes in the 1.7 release][release-notes-1.7].
 
 [jq-wiki-install]: https://github.com/jqlang/jq/wiki/Installation
+[release-notes-1.7]: https://github.com/jqlang/jq/releases/tag/jq-1.7

--- a/exercises/concept/regular-chatbot/.docs/introduction.md
+++ b/exercises/concept/regular-chatbot/.docs/introduction.md
@@ -121,7 +121,6 @@ The `scan` filter is similar to `match` with the `"g"` flag.
 ```jq
 STRING | scan(REGEX)
 STRING | scan(REGEX; FLAGS)
-STRING | scan([REGEX, FLAGS])
 ```
 
 `scan` will output a _stream_ of substrings.
@@ -140,6 +139,17 @@ Use the `[...]` array constructor to capture the substrings.
 "Goodbye Mars" | [ scan("[aeiou]") ]
 # => ["o", "o", "e", "a"]
 ```
+
+~~~~exercism/note
+Note that jq v1.6 does _not_ implement the 2-argument `scan` function, even though the version 1.6 manual [says it does][manual-scan-1.6]:
+
+* [version 1.7 source code][src-scan-1.7]
+* [version 1.6 source code][src-scan-1.6]
+
+[manual-scan-1.6]: https://jqlang.github.io/jq/manual/v1.6/#scan
+[src-scan-1.7]: https://github.com/jqlang/jq/blob/11c528d04d76c9b9553781aa76b073e4f40da008/src/builtin.jq#L92)
+[src-scan-1.6]: https://github.com/jqlang/jq/blob/2e01ff1fb69609540b2bdc4e62a60499f2b2fb8e/src/builtin.jq#L90)
+~~~~
 
 #### Splitting a String
 


### PR DESCRIPTION
Previous regular expression concept docs contained an error: there is no `scan([REGEX, FLAGS])` version of `scan` -- accepting an array is only valid for `test`/`match`/`capture` filters.

Add a note that `scan(REGEX; FLAGS)` is not actually implemented in v1.6, even though it is documented.

Add a suggestion to the INSTALLATION doc that v1.7 is worth installing.

Fixes #209 