### PR TITLE
feat: a new simple (correct) test that may break some accepted solutions

### DIFF
--- a/exercises/practice/protein-translation/test-protein-translation.bats
+++ b/exercises/practice/protein-translation/test-protein-translation.bats
@@ -366,7 +366,21 @@ END_INPUT
     assert_equal "$output" "$expected"
 }
 
-@test 'Non-existing codon can'\''t translate' {
+@test 'Sequence of two non-STOP codons is not matched to a STOP codon' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+
+    run jq -c -f protein-translation.jq << 'END_INPUT'
+        {
+          "strand": "AGUAGU"
+        }
+END_INPUT
+
+    assert_success
+    expected='["Methionine","Methionine"]'
+    assert_equal "$output" "$expected"
+}
+
+@test 'Non-existing codon can not translate' {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f protein-translation.jq << 'END_INPUT'
@@ -380,7 +394,7 @@ END_INPUT
     assert_equal "$output" "$expected"
 }
 
-@test 'Unknown amino acids, not part of a codon, can'\''t translate' {
+@test 'Unknown amino acids, not part of a codon, can not translate' {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f protein-translation.jq << 'END_INPUT'
@@ -394,7 +408,7 @@ END_INPUT
     assert_equal "$output" "$expected"
 }
 
-@test 'Incomplete RNA sequence can'\''t translate' {
+@test 'Incomplete RNA sequence can not translate' {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f protein-translation.jq << 'END_INPUT'


### PR DESCRIPTION
Some of the community solutions incorrectly try to locate STOP codons from input and strip anything that follows the first STOP codon.  This is a neat idea, but if the regex is not anchored, or if it does not align to groups of 3 - it's possible that a valid pair of codons (`AUGAUG`, for example,) creates a pattern that can cause the regex mis-identify a sequence as a STOP codon when it is on (`UGA`, in the previous example).

## Summary

A couple of the accepted solutions to this problem have a subtle bug that the tests are not catching.  This PR corrects that by putting a simple test in place.

<details><summary>Click to see examples...</summary>

![image](https://github.com/exercism/jq/assets/4342684/a34ae6dc-9c32-4df8-bb0e-a33536e6f6ad)

![image](https://github.com/exercism/jq/assets/4342684/8adea025-6c93-4245-bc1b-ef3ffd4344a4)

</details>

## Bonus

I noticed that the contractions in the test descriptions were not rendering correctly, so I changed them to non-contractions.
![image](https://github.com/exercism/jq/assets/4342684/a7d0e3cc-bdde-4d09-8b7f-7b62b22f260d)

## Checklist
- [ ] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
