### PR TITLE
Enable debug output

### DIFF
--- a/bin/validate_one_exercise
+++ b/bin/validate_one_exercise
@@ -48,7 +48,7 @@ trap cleanup EXIT
 dir=$(mktemp -d)
 cp "${solution}" "${dir}/${stub}"
 cp "${tests}" "${dir}/${tests}"
-cp bats-extra.bash "${editor_files[@]}" "${dir}"
+cp bats-*.bash "${editor_files[@]}" "${dir}"
 
 # Run the tests
 cd "${dir}"

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -3,9 +3,10 @@
 `jq` comes with a handy [`debug`][debug] filter.
 Use it while you are developing your exercise solutions to inspect the data that is currently in the jq pipline.
 
-`debug` print a "debug array" to **stderr**.
+`debug` prints a "debug array" to **stderr**.
+It outputs the input unchanged.
 The first element of the array is the string "DEBUG:".
-The second element depends on how you invoke `debug`:
+The second element depends on how you invoke `debug`.
 
 1. the zero-arity debug function puts a compact representation of the input into the array:
 
@@ -24,7 +25,7 @@ The second element depends on how you invoke `debug`:
      ]
     ```
 
-2. the one-arity version pipes the input through the given filter, prints the debug message, and outputs the input unchanged:
+2. the one-arity version pipes the input through the given filter:
 
     ```sh
     jq -n '[11, 22, 33] | debug("length: \(length), last: \(.[-1])") | map(. * 2)'
@@ -39,7 +40,8 @@ The second element depends on how you invoke `debug`:
      ]
     ```
 
-    The filter doesn't need to be a string, it can be anything, including multiple comma-separated expressions for "multi-line" debug output:
+    The filter doesn't need to be a string.
+    It can be anything, including multiple comma-separated expressions for "multi-line" debug output:
 
     ```sh
     jq -n '[11, 22, 33] as $a | 44 | debug("I am here:", $a, .)'

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,0 +1,56 @@
+# Tips for debugging in `jq`
+
+`jq` comes with a handy [`debug`][debug] filter.
+Use it while you are developing your exercise solutions to inspect the data that is currently in the jq pipline.
+
+`debug` print a "debug array" to **stderr**.
+The first element of the array is the string "DEBUG:".
+The second element depends on how you invoke `debug`:
+
+1. the zero-arity debug function puts a compact representation of the input into the array:
+
+    ```sh
+    jq -n '[11, 22, 33] | debug | map(. * 2)'
+    ```
+
+    outputs
+
+    ```none
+     ["DEBUG:",[11,22,33]]
+     [
+       22,
+       44,
+       66
+     ]
+    ```
+
+2. the one-arity version pipes the input through the given filter, prints the debug message, and outputs the input unchanged:
+
+    ```sh
+    jq -n '[11, 22, 33] | debug("length: \(length), last: \(.[-1])") | map(. * 2)'
+    ```
+
+    ```none
+     ["DEBUG:","length: 3, last: 33"]
+     [
+       22,
+       44,
+       66
+     ]
+    ```
+
+    The filter doesn't need to be a string, it can be anything, including multiple comma-separated expressions for "multi-line" debug output:
+
+    ```sh
+    jq -n '[11, 22, 33] as $a | 44 | debug("I am here:", $a, .)'
+    ```
+
+    ```none
+    ["DEBUG:","I am here:"]
+    ["DEBUG:",[11,22,33]]
+    ["DEBUG:",44]
+    44
+    ```
+
+
+[debug]: https://jqlang.github.io/jq/manual/v1.7/#debug

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -8,7 +8,7 @@ It outputs the input unchanged.
 The first element of the array is the string "DEBUG:".
 The second element depends on how you invoke `debug`.
 
-1. the zero-arity debug function puts a compact representation of the input into the array:
+1. the zero-arity debug function puts a compact representation of the input into the debug array:
 
     ```sh
     jq -n '[11, 22, 33] | debug | map(. * 2)'

--- a/docs/config.json
+++ b/docs/config.json
@@ -27,6 +27,13 @@
       "path": "docs/RESOURCES.md",
       "title": "Useful jq resources",
       "blurb": "A collection of useful resources to help you master jq"
+    },
+    {
+      "uuid": "d23a08e7-74aa-4402-a60b-3cc5bd4c5274",
+      "slug": "debugging",
+      "path": "docs/DEBUGGING.md",
+      "title": "How to debug in `jq`",
+      "blurb": "Some tips for using the `debug` function"
     }
   ]
 }

--- a/exercises/concept/assembly-line/bats-jq.bash
+++ b/exercises/concept/assembly-line/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/assembly-line/bats-jq.bash
+++ b/exercises/concept/assembly-line/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/assembly-line/test-assembly-line.bats
+++ b/exercises/concept/assembly-line/test-assembly-line.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 assert_float() {
     local OPTIND OPTARG

--- a/exercises/concept/bird-count/bats-jq.bash
+++ b/exercises/concept/bird-count/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/bird-count/bats-jq.bash
+++ b/exercises/concept/bird-count/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/bird-count/test-bird-count.bats
+++ b/exercises/concept/bird-count/test-bird-count.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 assert_key_value() {
     local key=$1 expected=$2 actual

--- a/exercises/concept/grade-stats/bats-jq.bash
+++ b/exercises/concept/grade-stats/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/grade-stats/bats-jq.bash
+++ b/exercises/concept/grade-stats/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/grade-stats/test-grade-stats.bats
+++ b/exercises/concept/grade-stats/test-grade-stats.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 assert_key_value() {
     local key=$1 expected=$2 actual

--- a/exercises/concept/high-score-board/bats-jq.bash
+++ b/exercises/concept/high-score-board/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/high-score-board/bats-jq.bash
+++ b/exercises/concept/high-score-board/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/high-score-board/test-high-score-board.bats
+++ b/exercises/concept/high-score-board/test-high-score-board.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 assert_key_value() {
     local key=$1 expected=$2 actual

--- a/exercises/concept/lasagna/bats-jq.bash
+++ b/exercises/concept/lasagna/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/lasagna/bats-jq.bash
+++ b/exercises/concept/lasagna/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/lasagna/test-lasagna.bats
+++ b/exercises/concept/lasagna/test-lasagna.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 assert_key_value() {
     local result

--- a/exercises/concept/log-line-parser/bats-jq.bash
+++ b/exercises/concept/log-line-parser/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/log-line-parser/bats-jq.bash
+++ b/exercises/concept/log-line-parser/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/log-line-parser/test-log-line-parser.bats
+++ b/exercises/concept/log-line-parser/test-log-line-parser.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 @test error_message {
     ## task 1

--- a/exercises/concept/recursive-functions/bats-jq.bash
+++ b/exercises/concept/recursive-functions/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/recursive-functions/bats-jq.bash
+++ b/exercises/concept/recursive-functions/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/recursive-functions/test-recursive-functions.bats
+++ b/exercises/concept/recursive-functions/test-recursive-functions.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 assert_key_value() {
     local result

--- a/exercises/concept/regular-chatbot/bats-jq.bash
+++ b/exercises/concept/regular-chatbot/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/regular-chatbot/bats-jq.bash
+++ b/exercises/concept/regular-chatbot/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/regular-chatbot/test-regular-chatbot.bats
+++ b/exercises/concept/regular-chatbot/test-regular-chatbot.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 @test 'recognizes a command at the first position' {
     ## task 1

--- a/exercises/concept/remote-control-car/bats-jq.bash
+++ b/exercises/concept/remote-control-car/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/remote-control-car/bats-jq.bash
+++ b/exercises/concept/remote-control-car/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/remote-control-car/test-remote-control-car.bats
+++ b/exercises/concept/remote-control-car/test-remote-control-car.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 assert_key_value() {
     local expected=$1 key=$2

--- a/exercises/concept/shopping/bats-jq.bash
+++ b/exercises/concept/shopping/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/shopping/bats-jq.bash
+++ b/exercises/concept/shopping/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/shopping/test-shopping.bats
+++ b/exercises/concept/shopping/test-shopping.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 @test "Show shopping list name" {
     ## task 1

--- a/exercises/concept/vehicle-purchase/bats-jq.bash
+++ b/exercises/concept/vehicle-purchase/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/concept/vehicle-purchase/bats-jq.bash
+++ b/exercises/concept/vehicle-purchase/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/concept/vehicle-purchase/test-vehicle-purchase.bats
+++ b/exercises/concept/vehicle-purchase/test-vehicle-purchase.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 @test requires_a_license_for_a_car {
     ## task 1

--- a/exercises/practice/acronym/bats-jq.bash
+++ b/exercises/practice/acronym/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/acronym/bats-jq.bash
+++ b/exercises/practice/acronym/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/acronym/test-acronym.bats
+++ b/exercises/practice/acronym/test-acronym.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2024-02-19T04:45:52Z
 load bats-extra
+load bats-jq
 
 @test 'basic' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/all-your-base/bats-jq.bash
+++ b/exercises/practice/all-your-base/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/all-your-base/bats-jq.bash
+++ b/exercises/practice/all-your-base/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/all-your-base/test-all-your-base.bats
+++ b/exercises/practice/all-your-base/test-all-your-base.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 
 load bats-extra
+load bats-jq
 
 @test 'single bit one to decimal' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/anagram/bats-jq.bash
+++ b/exercises/practice/anagram/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/anagram/bats-jq.bash
+++ b/exercises/practice/anagram/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/anagram/test-anagram.bats
+++ b/exercises/practice/anagram/test-anagram.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:58:55Z
 load bats-extra
+load bats-jq
 
 @test 'no matches' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/armstrong-numbers/bats-jq.bash
+++ b/exercises/practice/armstrong-numbers/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/armstrong-numbers/bats-jq.bash
+++ b/exercises/practice/armstrong-numbers/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/armstrong-numbers/test-armstrong-numbers.bats
+++ b/exercises/practice/armstrong-numbers/test-armstrong-numbers.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2024-06-14T21:01:19Z
 load bats-extra
+load bats-jq
 
 @test 'Zero is an Armstrong number' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/atbash-cipher/bats-jq.bash
+++ b/exercises/practice/atbash-cipher/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/atbash-cipher/bats-jq.bash
+++ b/exercises/practice/atbash-cipher/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/atbash-cipher/test-atbash-cipher.bats
+++ b/exercises/practice/atbash-cipher/test-atbash-cipher.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:58:57Z
 load bats-extra
+load bats-jq
 
 @test 'encode:encode yes' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/beer-song/bats-jq.bash
+++ b/exercises/practice/beer-song/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/beer-song/bats-jq.bash
+++ b/exercises/practice/beer-song/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/beer-song/test-beer-song.bats
+++ b/exercises/practice/beer-song/test-beer-song.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:58:59Z
 load bats-extra
+load bats-jq
 
 @test 'verse:single verse:first generic verse' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/binary-search/bats-jq.bash
+++ b/exercises/practice/binary-search/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/binary-search/bats-jq.bash
+++ b/exercises/practice/binary-search/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/binary-search/test-binary-search.bats
+++ b/exercises/practice/binary-search/test-binary-search.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 
 load bats-extra
+load bats-jq
 
 @test 'finds a value in an array with one element' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/bob/bats-jq.bash
+++ b/exercises/practice/bob/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/bob/bats-jq.bash
+++ b/exercises/practice/bob/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/bob/test-bob.bats
+++ b/exercises/practice/bob/test-bob.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:00Z
 load bats-extra
+load bats-jq
 
 @test 'stating something' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/collatz-conjecture/bats-jq.bash
+++ b/exercises/practice/collatz-conjecture/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/collatz-conjecture/bats-jq.bash
+++ b/exercises/practice/collatz-conjecture/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/collatz-conjecture/test-collatz-conjecture.bats
+++ b/exercises/practice/collatz-conjecture/test-collatz-conjecture.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:03Z
 load bats-extra
+load bats-jq
 
 @test 'zero steps for one' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/darts/bats-jq.bash
+++ b/exercises/practice/darts/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/darts/bats-jq.bash
+++ b/exercises/practice/darts/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/darts/test-darts.bats
+++ b/exercises/practice/darts/test-darts.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:04Z
 load bats-extra
+load bats-jq
 
 @test 'Missed target' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/difference-of-squares/bats-jq.bash
+++ b/exercises/practice/difference-of-squares/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/difference-of-squares/bats-jq.bash
+++ b/exercises/practice/difference-of-squares/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/difference-of-squares/test-difference-of-squares.bats
+++ b/exercises/practice/difference-of-squares/test-difference-of-squares.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2024-02-21T23:55:25Z
 load bats-extra
+load bats-jq
 
 @test 'Square the sum of the numbers up to the given number:square of sum 1' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/eliuds-eggs/bats-jq.bash
+++ b/exercises/practice/eliuds-eggs/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/eliuds-eggs/bats-jq.bash
+++ b/exercises/practice/eliuds-eggs/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/eliuds-eggs/test-pop-count.bats
+++ b/exercises/practice/eliuds-eggs/test-pop-count.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2023-10-18T13:03:37Z
 load bats-extra
+load bats-jq
 
 @test '0 eggs' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/etl/bats-jq.bash
+++ b/exercises/practice/etl/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/etl/bats-jq.bash
+++ b/exercises/practice/etl/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/etl/test-etl.bats
+++ b/exercises/practice/etl/test-etl.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2023-11-07T18:49:21Z
 load bats-extra
+load bats-jq
 
 assert_objects_equal() {
     local result=$(

--- a/exercises/practice/flatten-array/bats-jq.bash
+++ b/exercises/practice/flatten-array/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/flatten-array/bats-jq.bash
+++ b/exercises/practice/flatten-array/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/flatten-array/test-flatten-array.bats
+++ b/exercises/practice/flatten-array/test-flatten-array.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2023-08-17T10:24:18Z
 load bats-extra
+load bats-jq
 
 @test 'empty' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/forth/bats-jq.bash
+++ b/exercises/practice/forth/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/forth/bats-jq.bash
+++ b/exercises/practice/forth/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/forth/test-forth.bats
+++ b/exercises/practice/forth/test-forth.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:07Z
 load bats-extra
+load bats-jq
 
 @test 'parsing and numbers:numbers just get pushed onto the stack' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/gigasecond/bats-jq.bash
+++ b/exercises/practice/gigasecond/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/gigasecond/bats-jq.bash
+++ b/exercises/practice/gigasecond/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/gigasecond/test-gigasecond.bats
+++ b/exercises/practice/gigasecond/test-gigasecond.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 load bats-extra
+load bats-jq
 
 # Ensure date calculations are done using UTC time zone
 export TZ=UTC

--- a/exercises/practice/hamming/bats-jq.bash
+++ b/exercises/practice/hamming/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/hamming/bats-jq.bash
+++ b/exercises/practice/hamming/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/hamming/test-hamming.bats
+++ b/exercises/practice/hamming/test-hamming.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:12Z
 load bats-extra
+load bats-jq
 
 @test 'empty strands' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/hello-world/bats-jq.bash
+++ b/exercises/practice/hello-world/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/hello-world/bats-jq.bash
+++ b/exercises/practice/hello-world/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/hello-world/test-hello-world.bats
+++ b/exercises/practice/hello-world/test-hello-world.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:14Z
 load bats-extra
+load bats-jq
 
 @test 'Say Hi!' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/isogram/bats-jq.bash
+++ b/exercises/practice/isogram/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/isogram/bats-jq.bash
+++ b/exercises/practice/isogram/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/isogram/test-isogram.bats
+++ b/exercises/practice/isogram/test-isogram.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:14Z
 load bats-extra
+load bats-jq
 
 @test 'empty string' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/knapsack/bats-jq.bash
+++ b/exercises/practice/knapsack/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/knapsack/bats-jq.bash
+++ b/exercises/practice/knapsack/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/knapsack/test-knapsack.bats
+++ b/exercises/practice/knapsack/test-knapsack.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:16Z
 load bats-extra
+load bats-jq
 
 @test 'no items' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/largest-series-product/bats-jq.bash
+++ b/exercises/practice/largest-series-product/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/largest-series-product/bats-jq.bash
+++ b/exercises/practice/largest-series-product/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/largest-series-product/test-largest-series-product.bats
+++ b/exercises/practice/largest-series-product/test-largest-series-product.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2024-06-14T20:09:36Z
 load bats-extra
+load bats-jq
 
 @test 'finds the largest product if span equals length' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/leap/bats-jq.bash
+++ b/exercises/practice/leap/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/leap/bats-jq.bash
+++ b/exercises/practice/leap/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/leap/test-leap.bats
+++ b/exercises/practice/leap/test-leap.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:17Z
 load bats-extra
+load bats-jq
 
 @test 'year not divisible by 4 in common year' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/luhn/bats-jq.bash
+++ b/exercises/practice/luhn/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/luhn/bats-jq.bash
+++ b/exercises/practice/luhn/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/luhn/test-luhn.bats
+++ b/exercises/practice/luhn/test-luhn.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2023-08-25T13:21:10Z
 load bats-extra
+load bats-jq
 
 @test 'single digit strings can not be valid' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/matching-brackets/bats-jq.bash
+++ b/exercises/practice/matching-brackets/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/matching-brackets/bats-jq.bash
+++ b/exercises/practice/matching-brackets/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/matching-brackets/test-matching-brackets.bats
+++ b/exercises/practice/matching-brackets/test-matching-brackets.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 
 load bats-extra
+load bats-jq
 
 @test 'paired square brackets' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/meetup/bats-jq.bash
+++ b/exercises/practice/meetup/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/meetup/bats-jq.bash
+++ b/exercises/practice/meetup/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/meetup/test-meetup.bats
+++ b/exercises/practice/meetup/test-meetup.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:18Z
 load bats-extra
+load bats-jq
 
 @test 'when teenth Monday is the 13th, the first day of the teenth week' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/nth-prime/bats-jq.bash
+++ b/exercises/practice/nth-prime/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/nth-prime/bats-jq.bash
+++ b/exercises/practice/nth-prime/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/nth-prime/test-nth-prime.bats
+++ b/exercises/practice/nth-prime/test-nth-prime.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:29Z
 load bats-extra
+load bats-jq
 
 @test 'first prime' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/nucleotide-count/bats-jq.bash
+++ b/exercises/practice/nucleotide-count/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/nucleotide-count/bats-jq.bash
+++ b/exercises/practice/nucleotide-count/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/nucleotide-count/test-nucleotide-count.bats
+++ b/exercises/practice/nucleotide-count/test-nucleotide-count.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2023-11-07T18:49:21Z
 load bats-extra
+load bats-jq
 
 assert_objects_equal() {
     local result=$(

--- a/exercises/practice/pangram/bats-jq.bash
+++ b/exercises/practice/pangram/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/pangram/bats-jq.bash
+++ b/exercises/practice/pangram/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/pangram/test-pangram.bats
+++ b/exercises/practice/pangram/test-pangram.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 
 load bats-extra
+load bats-jq
 
 @test 'empty sentence' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/pig-latin/bats-jq.bash
+++ b/exercises/practice/pig-latin/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/pig-latin/bats-jq.bash
+++ b/exercises/practice/pig-latin/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/pig-latin/test-pig-latin.bats
+++ b/exercises/practice/pig-latin/test-pig-latin.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2024-06-07T20:49:24Z
 load bats-extra
+load bats-jq
 
 @test 'ay is added to words that start with vowels:word beginning with a' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/protein-translation/bats-jq.bash
+++ b/exercises/practice/protein-translation/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/protein-translation/bats-jq.bash
+++ b/exercises/practice/protein-translation/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/protein-translation/test-protein-translation.bats
+++ b/exercises/practice/protein-translation/test-protein-translation.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:34Z
 load bats-extra
+load bats-jq
 
 @test 'Empty RNA sequence results in no proteins' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/proverb/bats-jq.bash
+++ b/exercises/practice/proverb/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/proverb/bats-jq.bash
+++ b/exercises/practice/proverb/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/proverb/test-proverb.bats
+++ b/exercises/practice/proverb/test-proverb.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:37Z
 load bats-extra
+load bats-jq
 
 @test 'zero pieces' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/raindrops/bats-jq.bash
+++ b/exercises/practice/raindrops/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/raindrops/bats-jq.bash
+++ b/exercises/practice/raindrops/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/raindrops/test-raindrops.bats
+++ b/exercises/practice/raindrops/test-raindrops.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:38Z
 load bats-extra
+load bats-jq
 
 @test 'the sound for 1 is 1' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/resistor-color-duo/bats-jq.bash
+++ b/exercises/practice/resistor-color-duo/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/resistor-color-duo/bats-jq.bash
+++ b/exercises/practice/resistor-color-duo/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/resistor-color-duo/test-resistor-color-duo.bats
+++ b/exercises/practice/resistor-color-duo/test-resistor-color-duo.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:40Z
 load bats-extra
+load bats-jq
 
 @test 'Brown and black' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/resistor-color-trio/bats-jq.bash
+++ b/exercises/practice/resistor-color-trio/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/resistor-color-trio/bats-jq.bash
+++ b/exercises/practice/resistor-color-trio/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/resistor-color-trio/test-resistor-color-trio.bats
+++ b/exercises/practice/resistor-color-trio/test-resistor-color-trio.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2023-01-03T20:57:23Z
 load bats-extra
+load bats-jq
 
 @test 'Orange and orange and black' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/resistor-color/bats-jq.bash
+++ b/exercises/practice/resistor-color/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/resistor-color/bats-jq.bash
+++ b/exercises/practice/resistor-color/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/resistor-color/test-resistor-color.bats
+++ b/exercises/practice/resistor-color/test-resistor-color.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:40Z
 load bats-extra
+load bats-jq
 
 @test 'Color codes:Black' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/reverse-string/bats-jq.bash
+++ b/exercises/practice/reverse-string/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/reverse-string/bats-jq.bash
+++ b/exercises/practice/reverse-string/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/reverse-string/test-reverse-string.bats
+++ b/exercises/practice/reverse-string/test-reverse-string.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:42Z
 load bats-extra
+load bats-jq
 
 @test 'an empty string' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/rna-transcription/bats-jq.bash
+++ b/exercises/practice/rna-transcription/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/rna-transcription/bats-jq.bash
+++ b/exercises/practice/rna-transcription/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/rna-transcription/test-rna-transcription.bats
+++ b/exercises/practice/rna-transcription/test-rna-transcription.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:43Z
 load bats-extra
+load bats-jq
 
 @test 'Empty RNA sequence' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/robot-simulator/bats-jq.bash
+++ b/exercises/practice/robot-simulator/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/robot-simulator/bats-jq.bash
+++ b/exercises/practice/robot-simulator/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/robot-simulator/test-robot-simulator.bats
+++ b/exercises/practice/robot-simulator/test-robot-simulator.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 
 load bats-extra
+load bats-jq
 
 assert_objects_equal() {
     local result=$(

--- a/exercises/practice/roman-numerals/bats-jq.bash
+++ b/exercises/practice/roman-numerals/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/roman-numerals/bats-jq.bash
+++ b/exercises/practice/roman-numerals/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/roman-numerals/test-roman-numerals.bats
+++ b/exercises/practice/roman-numerals/test-roman-numerals.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2024-01-24T19:54:13Z
 load bats-extra
+load bats-jq
 
 @test '1 is I' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/rotational-cipher/bats-jq.bash
+++ b/exercises/practice/rotational-cipher/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/rotational-cipher/bats-jq.bash
+++ b/exercises/practice/rotational-cipher/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/rotational-cipher/test-rotational-cipher.bats
+++ b/exercises/practice/rotational-cipher/test-rotational-cipher.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 
 load bats-extra
+load bats-jq
 
 @test 'rotate a by 0, same output as input' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/run-length-encoding/bats-jq.bash
+++ b/exercises/practice/run-length-encoding/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/run-length-encoding/bats-jq.bash
+++ b/exercises/practice/run-length-encoding/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/run-length-encoding/test-run-length-encoding.bats
+++ b/exercises/practice/run-length-encoding/test-run-length-encoding.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:44Z
 load bats-extra
+load bats-jq
 
 @test 'run-length encode a string:empty string' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/satellite/bats-jq.bash
+++ b/exercises/practice/satellite/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/satellite/bats-jq.bash
+++ b/exercises/practice/satellite/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/satellite/test-satellite.bats
+++ b/exercises/practice/satellite/test-satellite.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2023-11-07T18:49:22Z
 load bats-extra
+load bats-jq
 
 assert_objects_equal() {
     local result=$(

--- a/exercises/practice/scrabble-score/bats-jq.bash
+++ b/exercises/practice/scrabble-score/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/scrabble-score/bats-jq.bash
+++ b/exercises/practice/scrabble-score/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/scrabble-score/test-scrabble-score.bats
+++ b/exercises/practice/scrabble-score/test-scrabble-score.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:47Z
 load bats-extra
+load bats-jq
 
 @test 'lowercase letter' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/series/bats-jq.bash
+++ b/exercises/practice/series/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/series/bats-jq.bash
+++ b/exercises/practice/series/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/series/test-series.bats
+++ b/exercises/practice/series/test-series.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2023-08-25T15:56:38Z
 load bats-extra
+load bats-jq
 
 @test 'slices of one from one' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/sieve/bats-jq.bash
+++ b/exercises/practice/sieve/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/sieve/bats-jq.bash
+++ b/exercises/practice/sieve/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/sieve/test-sieve.bats
+++ b/exercises/practice/sieve/test-sieve.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:48Z
 load bats-extra
+load bats-jq
 
 @test 'no primes under two' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/space-age/bats-jq.bash
+++ b/exercises/practice/space-age/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/space-age/bats-jq.bash
+++ b/exercises/practice/space-age/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/space-age/test-space-age.bats
+++ b/exercises/practice/space-age/test-space-age.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:49Z
 load bats-extra
+load bats-jq
 
 @test 'age on Earth' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/square-root/bats-jq.bash
+++ b/exercises/practice/square-root/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/square-root/bats-jq.bash
+++ b/exercises/practice/square-root/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/square-root/test-square-root.bats
+++ b/exercises/practice/square-root/test-square-root.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:50Z
 load bats-extra
+load bats-jq
 
 @test 'root of 1' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/transpose/bats-jq.bash
+++ b/exercises/practice/transpose/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/transpose/bats-jq.bash
+++ b/exercises/practice/transpose/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/transpose/test-transpose.bats
+++ b/exercises/practice/transpose/test-transpose.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:51Z
 load bats-extra
+load bats-jq
 
 @test 'empty string' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/two-bucket/bats-jq.bash
+++ b/exercises/practice/two-bucket/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/two-bucket/bats-jq.bash
+++ b/exercises/practice/two-bucket/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/two-bucket/test-two-bucket.bats
+++ b/exercises/practice/two-bucket/test-two-bucket.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2023-11-07T18:49:23Z
 load bats-extra
+load bats-jq
 
 assert_objects_equal() {
     local result=$(

--- a/exercises/practice/two-fer/bats-jq.bash
+++ b/exercises/practice/two-fer/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/two-fer/bats-jq.bash
+++ b/exercises/practice/two-fer/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/two-fer/test-two-fer.bats
+++ b/exercises/practice/two-fer/test-two-fer.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:54Z
 load bats-extra
+load bats-jq
 
 @test 'no name given' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/yacht/bats-jq.bash
+++ b/exercises/practice/yacht/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/yacht/bats-jq.bash
+++ b/exercises/practice/yacht/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/yacht/test-yacht.bats
+++ b/exercises/practice/yacht/test-yacht.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2024-06-07T22:08:03Z
 load bats-extra
+load bats-jq
 
 @test 'Yacht' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/zebra-puzzle/bats-jq.bash
+++ b/exercises/practice/zebra-puzzle/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/exercises/practice/zebra-puzzle/bats-jq.bash
+++ b/exercises/practice/zebra-puzzle/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}

--- a/exercises/practice/zebra-puzzle/test-zebra-puzzle.bats
+++ b/exercises/practice/zebra-puzzle/test-zebra-puzzle.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # generated on 2022-11-02T20:59:55Z
 load bats-extra
+load bats-jq
 
 @test 'resident who drinks water' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/shared/.docs/debug.md
+++ b/exercises/shared/.docs/debug.md
@@ -1,0 +1,8 @@
+# Debugging in `jq`
+
+`jq` comes with a handy [`debug`][debug] filter.
+Use it while you are developing your exercise solutions to inspect the data that is currently in the jq pipline.
+See the [debugging doc][debugging] for more details.
+
+[debug]: https://jqlang.github.io/jq/manual/v1.7/#debug
+[debugging]: /docs/tracks/jq/debugging

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,10 +1,11 @@
 # Help
 
-Need help?
+## Need more help?
 
 - Go to the [Exercism Community forum](https://forum.exercism.org) to get support and ask questions (or just chat!)
   - Use the [Exercism Support](https://forum.exercism.org/c/support/8) category if you face any issues with working in the web editor, or downloading or submitting your exercises locally.
   - Use the [Programming:jq](https://forum.exercism.org/c/programming/jq/133) category for jq-specific topics.
+- Join the community on [Exercism's Discord server](https://exercism.org/r/discord).
 - [StackOverflow](https://stackoverflow.com/questions/tagged/jq) can be used to search for your problem and see if it has been answered already.
   You can also ask and answer questions.
 - [Github issue tracker](https://github.com/exercism/jq/issues) is where we track our development and maintainance of `jq` exercises in exercism.

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -65,7 +65,16 @@ Then run tests with just:
 bats
 ```
 
+## Debugging in `jq`
+
+`jq` comes with a handy [`debug`][debug] filter.
+Use it while you are developing your exercise solutions to inspect the data that is currently in the jq pipline.
+See the [debugging doc][debugging] for more details.
+
+
 [bash]: https://exercism.org/docs/tracks/bash/tests
 [bats-assert]: https://github.com/bats-core/bats-assert
 [here-string]: https://www.gnu.org/software/bash/manual/bash.html#Here-Strings
 [so]: https://unix.stackexchange.com/a/80372/4667
+[debug]: https://jqlang.github.io/jq/manual/v1.7/#debug
+[debugging]: /docs/tracks/jq/debugging

--- a/lib/README.md
+++ b/lib/README.md
@@ -11,20 +11,10 @@ Also in here, bats files common to all exercises.
 
     ```bash
     for e in ./exercises/{concept,practice}/*/; do
-        cp -nvt "$e" ./lib/bats-*.bash
-    done
-    ```
-
-* to ensure every exercise is using what's in this directory:
-
-    ```bash
-    for e in ./exercises/{concept,practice}/*/; do
         for f in ./lib/bats-*.bash; do
             g=$(basename "$f")
-            if [[ -f "$e/$g" ]]; then
-                cmp "$e/$g" "./lib/$g" || echo "different: $e/$g"
-            else
-                echo "missing: $e/$g"
+            if [[ ! -f "$e/$g" ]] || ! cmp "$e/$g" "./lib/$g"; then
+                cp -vp "./lib/$g" "$e/$g"
             fi
         done
     done

--- a/lib/README.md
+++ b/lib/README.md
@@ -2,3 +2,30 @@ This directory may not stay.
 It does not have a bearing on the functionality of the track.
 
 For now, it's a place to store code the practice exercises may reuse.
+
+## bats files
+
+Also in here, bats files common to all exercises.
+
+* to deploy bats files to all exercises:
+
+    ```bash
+    for e in ./exercises/{concept,practice}/*/; do
+        cp -nvt "$e" ./lib/bats-*.bash
+    done
+    ```
+
+* to ensure every exercise is using what's in this directory:
+
+    ```bash
+    for e in ./exercises/{concept,practice}/*/; do
+        for f in ./lib/bats-*.bash; do
+            g=$(basename "$f")
+            if [[ -f "$e/$g" ]]; then
+                cmp "$e/$g" "./lib/$g" || echo "different: $e/$g"
+            else
+                echo "missing: $e/$g"
+            fi
+        done
+    done
+    ```

--- a/lib/bats-extra.bash
+++ b/lib/bats-extra.bash
@@ -1,0 +1,637 @@
+# This is the source code for bats-support and bats-assert, concatenated
+# * https://github.com/bats-core/bats-support
+# * https://github.com/bats-core/bats-assert
+#
+# Comments have been removed to save space. See the git repos for full source code.
+
+############################################################
+#
+# bats-support - Supporting library for Bats test helpers
+#
+# Written in 2016 by Zoltan Tombol <zoltan dot tombol at gmail dot com>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any
+# warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+# <http://creativecommons.org/publicdomain/zero/1.0/>.
+#
+
+fail() {
+  (( $# == 0 )) && batslib_err || batslib_err "$@"
+  return 1
+}
+
+batslib_is_caller() {
+  local -i is_mode_direct=1
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+      -i|--indirect) is_mode_direct=0; shift ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  # Arguments.
+  local -r func="$1"
+
+  # Check call stack.
+  if (( is_mode_direct )); then
+    [[ $func == "${FUNCNAME[2]}" ]] && return 0
+  else
+    local -i depth
+    for (( depth=2; depth<${#FUNCNAME[@]}; ++depth )); do
+      [[ $func == "${FUNCNAME[$depth]}" ]] && return 0
+    done
+  fi
+
+  return 1
+}
+
+batslib_err() {
+  { if (( $# > 0 )); then
+      echo "$@"
+    else
+      cat -
+    fi
+  } >&2
+}
+
+batslib_count_lines() {
+  local -i n_lines=0
+  local line
+  while IFS='' read -r line || [[ -n $line ]]; do
+    (( ++n_lines ))
+  done < <(printf '%s' "$1")
+  echo "$n_lines"
+}
+
+batslib_is_single_line() {
+  for string in "$@"; do
+    (( $(batslib_count_lines "$string") > 1 )) && return 1
+  done
+  return 0
+}
+
+batslib_get_max_single_line_key_width() {
+  local -i max_len=-1
+  while (( $# != 0 )); do
+    local -i key_len="${#1}"
+    batslib_is_single_line "$2" && (( key_len > max_len )) && max_len="$key_len"
+    shift 2
+  done
+  echo "$max_len"
+}
+
+batslib_print_kv_single() {
+  local -ir col_width="$1"; shift
+  while (( $# != 0 )); do
+    printf '%-*s : %s\n' "$col_width" "$1" "$2"
+    shift 2
+  done
+}
+
+batslib_print_kv_multi() {
+  while (( $# != 0 )); do
+    printf '%s (%d lines):\n' "$1" "$( batslib_count_lines "$2" )"
+    printf '%s\n' "$2"
+    shift 2
+  done
+}
+
+batslib_print_kv_single_or_multi() {
+  local -ir width="$1"; shift
+  local -a pairs=( "$@" )
+
+  local -a values=()
+  local -i i
+  for (( i=1; i < ${#pairs[@]}; i+=2 )); do
+    values+=( "${pairs[$i]}" )
+  done
+
+  if batslib_is_single_line "${values[@]}"; then
+    batslib_print_kv_single "$width" "${pairs[@]}"
+  else
+    local -i i
+    for (( i=1; i < ${#pairs[@]}; i+=2 )); do
+      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+    done
+    batslib_print_kv_multi "${pairs[@]}"
+  fi
+}
+
+batslib_prefix() {
+  local -r prefix="${1:-  }"
+  local line
+  while IFS='' read -r line || [[ -n $line ]]; do
+    printf '%s%s\n' "$prefix" "$line"
+  done
+}
+
+batslib_mark() {
+  local -r symbol="$1"; shift
+  # Sort line numbers.
+  set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
+
+  local line
+  local -i idx=0
+  while IFS='' read -r line || [[ -n $line ]]; do
+    if (( ${1:--1} == idx )); then
+      printf '%s\n' "${symbol}${line:${#symbol}}"
+      shift
+    else
+      printf '%s\n' "$line"
+    fi
+    (( ++idx ))
+  done
+}
+
+batslib_decorate() {
+  echo
+  echo "-- $1 --"
+  cat -
+  echo '--'
+  echo
+}
+
+############################################################
+
+assert() {
+  if ! "$@"; then
+    batslib_print_kv_single 10 'expression' "$*" \
+    | batslib_decorate 'assertion failed' \
+    | fail
+  fi
+}
+
+assert_equal() {
+  if [[ $1 != "$2" ]]; then
+    batslib_print_kv_single_or_multi 8 \
+    'expected' "$2" \
+    'actual'   "$1" \
+    | batslib_decorate 'values do not equal' \
+    | fail
+  fi
+}
+
+assert_failure() {
+  : "${output?}"
+  : "${status?}"
+
+  (( $# > 0 )) && local -r expected="$1"
+  if (( status == 0 )); then
+    batslib_print_kv_single_or_multi 6 'output' "$output" \
+    | batslib_decorate 'command succeeded, but it was expected to fail' \
+    | fail
+  elif (( $# > 0 )) && (( status != expected )); then
+    { local -ir width=8
+      batslib_print_kv_single "$width" \
+      'expected' "$expected" \
+      'actual'   "$status"
+      batslib_print_kv_single_or_multi "$width" \
+      'output' "$output"
+    } \
+    | batslib_decorate 'command failed as expected, but status differs' \
+    | fail
+  fi
+}
+
+assert_line() {
+  local -i is_match_line=0
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  : "${lines?}"
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+    -n|--index)
+      if (( $# < 2 )) || ! [[ $2 =~ ^([0-9]|[1-9][0-9]+)$ ]]; then
+        echo "\`--index' requires an integer argument: \`$2'" \
+        | batslib_decorate 'ERROR: assert_line' \
+        | fail
+        return $?
+      fi
+      is_match_line=1
+      local -ri idx="$2"
+      shift 2
+      ;;
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: assert_line' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local -r expected="$1"
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $expected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$expected'" \
+    | batslib_decorate 'ERROR: assert_line' \
+    | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_match_line )); then
+    # Specific line.
+    if (( is_mode_regexp )); then
+      if ! [[ ${lines[$idx]} =~ $expected ]]; then
+        batslib_print_kv_single 6 \
+        'index' "$idx" \
+        'regexp' "$expected" \
+        'line'  "${lines[$idx]}" \
+        | batslib_decorate 'regular expression does not match line' \
+        | fail
+      fi
+    elif (( is_mode_partial )); then
+      if [[ ${lines[$idx]} != *"$expected"* ]]; then
+        batslib_print_kv_single 9 \
+        'index'     "$idx" \
+        'substring' "$expected" \
+        'line'      "${lines[$idx]}" \
+        | batslib_decorate 'line does not contain substring' \
+        | fail
+      fi
+    else
+      if [[ ${lines[$idx]} != "$expected" ]]; then
+        batslib_print_kv_single 8 \
+        'index'    "$idx" \
+        'expected' "$expected" \
+        'actual'   "${lines[$idx]}" \
+        | batslib_decorate 'line differs' \
+        | fail
+      fi
+    fi
+  else
+    # Contained in output.
+    if (( is_mode_regexp )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} =~ $expected ]] && return 0
+      done
+      { local -ar single=( 'regexp' "$expected" )
+        local -ar may_be_multi=( 'output' "$output" )
+        local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } \
+      | batslib_decorate 'no output line matches regular expression' \
+      | fail
+    elif (( is_mode_partial )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} == *"$expected"* ]] && return 0
+      done
+      { local -ar single=( 'substring' "$expected" )
+        local -ar may_be_multi=( 'output' "$output" )
+        local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } \
+      | batslib_decorate 'no output line contains substring' \
+      | fail
+    else
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} == "$expected" ]] && return 0
+      done
+      { local -ar single=( 'line' "$expected" )
+        local -ar may_be_multi=( 'output' "$output" )
+        local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } \
+      | batslib_decorate 'output does not contain line' \
+      | fail
+    fi
+  fi
+}
+
+assert_output() {
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  local -i is_mode_nonempty=0
+  local -i use_stdin=0
+  : "${output?}"
+
+  # Handle options.
+  if (( $# == 0 )); then
+    is_mode_nonempty=1
+  fi
+
+  while (( $# > 0 )); do
+    case "$1" in
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    -|--stdin) use_stdin=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: assert_output' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local expected
+  if (( use_stdin )); then
+    expected="$(cat -)"
+  else
+    expected="${1-}"
+  fi
+
+  # Matching.
+  if (( is_mode_nonempty )); then
+    if [ -z "$output" ]; then
+      echo 'expected non-empty output, but output was empty' \
+      | batslib_decorate 'no output' \
+      | fail
+    fi
+  elif (( is_mode_regexp )); then
+    if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      echo "Invalid extended regular expression: \`$expected'" \
+      | batslib_decorate 'ERROR: assert_output' \
+      | fail
+    elif ! [[ $output =~ $expected ]]; then
+      batslib_print_kv_single_or_multi 6 \
+      'regexp'  "$expected" \
+      'output' "$output" \
+      | batslib_decorate 'regular expression does not match output' \
+      | fail
+    fi
+  elif (( is_mode_partial )); then
+    if [[ $output != *"$expected"* ]]; then
+      batslib_print_kv_single_or_multi 9 \
+      'substring' "$expected" \
+      'output'    "$output" \
+      | batslib_decorate 'output does not contain substring' \
+      | fail
+    fi
+  else
+    if [[ $output != "$expected" ]]; then
+      batslib_print_kv_single_or_multi 8 \
+      'expected' "$expected" \
+      'actual'   "$output" \
+      | batslib_decorate 'output differs' \
+      | fail
+    fi
+  fi
+}
+
+assert_success() {
+  : "${output?}"
+  : "${status?}"
+
+  if (( status != 0 )); then
+    { local -ir width=6
+      batslib_print_kv_single "$width" 'status' "$status"
+      batslib_print_kv_single_or_multi "$width" 'output' "$output"
+    } \
+    | batslib_decorate 'command failed' \
+    | fail
+  fi
+}
+
+refute() {
+  if "$@"; then
+    batslib_print_kv_single 10 'expression' "$*" \
+    | batslib_decorate 'assertion succeeded, but it was expected to fail' \
+    | fail
+  fi
+}
+
+refute_line() {
+  local -i is_match_line=0
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  : "${lines?}"
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+    -n|--index)
+      if (( $# < 2 )) || ! [[ $2 =~ ^([0-9]|[1-9][0-9]+)$ ]]; then
+        echo "\`--index' requires an integer argument: \`$2'" \
+        | batslib_decorate 'ERROR: refute_line' \
+        | fail
+        return $?
+      fi
+      is_match_line=1
+      local -ri idx="$2"
+      shift 2
+      ;;
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: refute_line' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local -r unexpected="$1"
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $unexpected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$unexpected'" \
+    | batslib_decorate 'ERROR: refute_line' \
+    | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_match_line )); then
+    # Specific line.
+    if (( is_mode_regexp )); then
+      if [[ ${lines[$idx]} =~ $unexpected ]]; then
+        batslib_print_kv_single 6 \
+        'index' "$idx" \
+        'regexp' "$unexpected" \
+        'line'  "${lines[$idx]}" \
+        | batslib_decorate 'regular expression should not match line' \
+        | fail
+      fi
+    elif (( is_mode_partial )); then
+      if [[ ${lines[$idx]} == *"$unexpected"* ]]; then
+        batslib_print_kv_single 9 \
+        'index'     "$idx" \
+        'substring' "$unexpected" \
+        'line'      "${lines[$idx]}" \
+        | batslib_decorate 'line should not contain substring' \
+        | fail
+      fi
+    else
+      if [[ ${lines[$idx]} == "$unexpected" ]]; then
+        batslib_print_kv_single 5 \
+        'index' "$idx" \
+        'line'  "${lines[$idx]}" \
+        | batslib_decorate 'line should differ' \
+        | fail
+      fi
+    fi
+  else
+    # Line contained in output.
+    if (( is_mode_regexp )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} =~ $unexpected ]]; then
+          { local -ar single=( 'regexp' "$unexpected" 'index' "$idx" )
+            local -a may_be_multi=( 'output' "$output" )
+            local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" | batslib_prefix | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } \
+          | batslib_decorate 'no line should match the regular expression' \
+          | fail
+          return $?
+        fi
+      done
+    elif (( is_mode_partial )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == *"$unexpected"* ]]; then
+          { local -ar single=( 'substring' "$unexpected" 'index' "$idx" )
+            local -a may_be_multi=( 'output' "$output" )
+            local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" | batslib_prefix | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } \
+          | batslib_decorate 'no line should contain substring' \
+          | fail
+          return $?
+        fi
+      done
+    else
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == "$unexpected" ]]; then
+          { local -ar single=( 'line' "$unexpected" 'index' "$idx" )
+            local -a may_be_multi=( 'output' "$output" )
+            local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" | batslib_prefix | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } \
+          | batslib_decorate 'line should not be in output' \
+          | fail
+          return $?
+        fi
+      done
+    fi
+  fi
+}
+
+refute_output() {
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  local -i is_mode_empty=0
+  local -i use_stdin=0
+  : "${output?}"
+
+  # Handle options.
+  if (( $# == 0 )); then
+    is_mode_empty=1
+  fi
+
+  while (( $# > 0 )); do
+    case "$1" in
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    -|--stdin) use_stdin=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: refute_output' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local unexpected
+  if (( use_stdin )); then
+    unexpected="$(cat -)"
+  else
+    unexpected="${1-}"
+  fi
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $unexpected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$unexpected'" \
+    | batslib_decorate 'ERROR: refute_output' \
+    | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_mode_empty )); then
+    if [ -n "$output" ]; then
+      batslib_print_kv_single_or_multi 6 \
+      'output' "$output" \
+      | batslib_decorate 'output non-empty, but expected no output' \
+      | fail
+    fi
+  elif (( is_mode_regexp )); then
+    if [[ $output =~ $unexpected ]]; then
+      batslib_print_kv_single_or_multi 6 \
+      'regexp'  "$unexpected" \
+      'output' "$output" \
+      | batslib_decorate 'regular expression should not match output' \
+      | fail
+    fi
+  elif (( is_mode_partial )); then
+    if [[ $output == *"$unexpected"* ]]; then
+      batslib_print_kv_single_or_multi 9 \
+      'substring' "$unexpected" \
+      'output'    "$output" \
+      | batslib_decorate 'output should not contain substring' \
+      | fail
+    fi
+  else
+    if [[ $output == "$unexpected" ]]; then
+      batslib_print_kv_single_or_multi 6 \
+      'output' "$output" \
+      | batslib_decorate 'output equals, but it was expected to differ' \
+      | fail
+    fi
+  fi
+}

--- a/lib/bats-jq.bash
+++ b/lib/bats-jq.bash
@@ -12,7 +12,7 @@
 
 
 jq() {
-    local output stderr rc
+    local output stderr rc line
     stderr=$(mktemp)
     output=$(command jq "$@" 2> "$stderr")
     rc=$?
@@ -23,7 +23,7 @@ jq() {
             echo "$line" >&2
         fi
     done < "$stderr"
-    rm "$stderr"
+    rm -f "$stderr"
     echo "$output"
-    return $rc
+    return "$rc"
 }

--- a/lib/bats-jq.bash
+++ b/lib/bats-jq.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# `bats-core` will consume both stdout and stderr for the `run` command's output.
+# However `jq` prints its DEBUG output on stderr.
+#
+# Lines starting with `["DEBUG:",` will be prefixed with a hash and printed on file descriptor 3.
+# Other lines on stderr will remain on stderr for bats to consume.
+#
+# See `bats-core` docs:
+# - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
+# - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
+
+
+jq() {
+    local output stderr rc
+    stderr=$(mktemp)
+    output=$(command jq "$@" 2> "$stderr")
+    rc=$?
+    while IFS= read -r line || [[ -n $line ]]; do
+        if [[ $line == '["DEBUG:",'* ]]; then
+            echo "# $line" >&3
+        else
+            echo "$line" >&2
+        fi
+    done < "$stderr"
+    rm "$stderr"
+    echo "$output"
+    return $rc
+}


### PR DESCRIPTION
The purpose of this PR is to separate jq's debug output from the rest of the stderr output, so that bats can handle it properly.

This is a companion PR to exercism/jq-test-runner#33 -- I suggest merging that one first. 

This is a pretty big PR. You might want to read each commit individually.