### PR TITLE
Add url base exercism.org

### DIFF
--- a/exercises/concept/recursive-functions/.docs/hints.md
+++ b/exercises/concept/recursive-functions/.docs/hints.md
@@ -26,5 +26,5 @@
 - To apply the filter parameter to an element, use the usual pipe syntax: `.element | filter`.
 - The base case is an empty array.
 
-[arrays-concept]: /tracks/jq/concepts/arrays
+[arrays-concept]: https://exercism.org/tracks/jq/concepts/arrays
 [manual-addition]: https://jqlang.github.io/jq/manual/v1.7/#addition

--- a/exercises/shared/.docs/debug.md
+++ b/exercises/shared/.docs/debug.md
@@ -5,4 +5,4 @@ Use it while you are developing your exercise solutions to inspect the data that
 See the [debugging doc][debugging] for more details.
 
 [debug]: https://jqlang.github.io/jq/manual/v1.7/#debug
-[debugging]: /docs/tracks/jq/debugging
+[debugging]: https://exercism.org/docs/tracks/jq/debugging

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -77,4 +77,4 @@ See the [debugging doc][debugging] for more details.
 [here-string]: https://www.gnu.org/software/bash/manual/bash.html#Here-Strings
 [so]: https://unix.stackexchange.com/a/80372/4667
 [debug]: https://jqlang.github.io/jq/manual/v1.7/#debug
-[debugging]: /docs/tracks/jq/debugging
+[debugging]: https://exercism.org/docs/tracks/jq/debugging


### PR DESCRIPTION
## Summary

Some links to https://exercism.org pages are root-relative, which worked only in the website (when markdowns are parsed to html) but not locally (markdown as is).

Popular tracks `exercism/java` and `exercism/python` both use non root-relative links to exercism.org, so this change should be safe
- https://github.com/search?q=repo%3Aexercism%2Fpython+docs%2Ftracks%2Fpython&type=code
- https://github.com/search?q=repo%3Aexercism%2Fjava+docs%2Ftracks%2Fjava&type=code

## Checklist
- [x] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
