### PR TITLE
Add step to fetch configlet to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,5 @@
 
 
 ## Checklist
-- [ ] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
+- [ ] If docs where changed, run `./bin/fetch-configlet && ./bin/configlet generate` to ensure all documents are properly generated.
 - [ ] CI is green


### PR DESCRIPTION
## Summary

Program `configlet` mentioned in the Checklist of PR template is not contained in this repo. This PR adds the step to fetch the latest `configlet`.

I noticed this repo also contains a [`fetch-configlet.ps1`](https://github.com/exercism/jq/blob/8cbe3b7d81d01038b1d6b01ccddb0578554544fc/bin/fetch-configlet.ps1) for Windows PowerShell users. Is it recommended to also add a variant for Windows users?

TODO: Sync the change to https://github.com/exercism/common-lisp, from where the `.github/pull_request_template.md` is copied. See https://github.com/exercism/jq/issues/106.

## Checklist
- [ ] If docs where changed, run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
