### PR TITLE
Update test-largest-series-product.bats

### DIFF
--- a/exercises/practice/largest-series-product/test-largest-series-product.bats
+++ b/exercises/practice/largest-series-product/test-largest-series-product.bats
@@ -149,7 +149,7 @@ END_INPUT
 END_INPUT
 
     assert_failure
-    expected='span must be smaller than string length'
+    expected='string length must not be smaller than span'
     assert_equal "$output" "$expected"
 }
 
@@ -194,7 +194,7 @@ END_INPUT
 END_INPUT
 
     assert_failure
-    expected='span must be smaller than string length'
+    expected='string length must not be smaller than span'
     assert_equal "$output" "$expected"
 }
 


### PR DESCRIPTION
"span must be smaller than string length" conflicts with the first test. It should read something like "string length cannot be smaller than span" because span and string length can be equal.

## Summary

improve the error message


## Checklist
- [ ] If docs where changed, run `./bin/fetch-configlet && ./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
