### PR TITLE
upgrade to jq 1.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Install software
         run: |
           sudo apt update && sudo apt -y install bats &&
-          sudo curl -L -o /usr/bin/jq  https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 &&
+          sudo curl -L -o /usr/bin/jq  https://github.com/jqlang/jq/releases/download/jq-1.8.0/jq-linux-amd64 &&
           sudo chmod -v 755 /usr/bin/jq
 
       - name: Run tests for all exercises
-        run: bash bin/ci
+        run: bash bin/validate_exercises

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install software
         run: |
           sudo apt update && sudo apt -y install bats &&
-          sudo curl -L -o /usr/bin/jq  https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 &&
+          sudo curl -L -o /usr/bin/jq  https://github.com/jqlang/jq/releases/download/jq-1.8.0/jq-linux-amd64 &&
           sudo chmod -v 755 /usr/bin/jq
 
       - name: Run tests for changed/added exercises

--- a/bin/ci
+++ b/bin/ci
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# invoked by .github/workflows/ci.yml
-
-bin/validate_exercises

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -56,5 +56,5 @@ We will assume you are familiar with [JSON syntax and data types][wiki-json].
 [so]: https://stackoverflow.com/tags/jq/info
 [json]: https://www.json.org
 [wiki-json]: https://en.wikipedia.org/wiki/JSON#Syntax
-[cli-options]: https://jqlang.github.io/jq/manual/v1.8/#invoking-jq
+[cli-options]: https://jqlang.github.io/jq/manual/#invoking-jq
 [gojq]: https://github.com/itchyny/gojq#gojq

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -56,5 +56,5 @@ We will assume you are familiar with [JSON syntax and data types][wiki-json].
 [so]: https://stackoverflow.com/tags/jq/info
 [json]: https://www.json.org
 [wiki-json]: https://en.wikipedia.org/wiki/JSON#Syntax
-[cli-options]: https://jqlang.github.io/jq/manual/v1.7/#invoking-jq
+[cli-options]: https://jqlang.github.io/jq/manual/v1.8/#invoking-jq
 [gojq]: https://github.com/itchyny/gojq#gojq

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -55,4 +55,4 @@ The second element depends on how you invoke `debug`.
     ```
 
 
-[debug]: https://jqlang.github.io/jq/manual/v1.7/#debug
+[debug]: https://jqlang.github.io/jq/manual/v1.8/#debug

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -55,4 +55,4 @@ The second element depends on how you invoke `debug`.
     ```
 
 
-[debug]: https://jqlang.github.io/jq/manual/v1.8/#debug
+[debug]: https://jqlang.github.io/jq/manual/#debug

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,7 +8,6 @@ As of June 2025, the current jq release is version **1.8**.
 This is the version used in the online jq test runner.
 
 Many Linux package managers will install an older release, version 1.6.
-It's worth installing the newer version: there were [substantial changes in the 1.7 release][release-notes-1.7].
+You should install a newer version manually: there have been many beneficial changes since v1.6 was released in 2018.
 
 [jq-wiki-install]: https://github.com/jqlang/jq/wiki/Installation
-[release-notes-1.7]: https://github.com/jqlang/jq/releases/tag/jq-1.7

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -4,10 +4,10 @@ Please head to [the `jq` wiki][jq-wiki-install] for the installation instruction
 
 ## Version Information
 
-As of October 2023, the current jq release is version 1.7.
+As of June 2025, the current jq release is version **1.8**.
 This is the version used in the online jq test runner.
 
-Most Linux package managers will install the previous release, version 1.6.
+Many Linux package managers will install an older release, version 1.6.
 It's worth installing the newer version: there were [substantial changes in the 1.7 release][release-notes-1.7].
 
 [jq-wiki-install]: https://github.com/jqlang/jq/wiki/Installation

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,6 +8,6 @@ As of June 2025, the current jq release is version **1.8**.
 This is the version used in the online jq test runner.
 
 Many Linux package managers will install an older release, version 1.6.
-You should install a newer version manually: there have been many beneficial changes since v1.6 was released in 2018.
+You should install a newer version manually; there have been many beneficial changes since v1.6 was released in 2018.
 
 [jq-wiki-install]: https://github.com/jqlang/jq/wiki/Installation

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -6,8 +6,8 @@ Or, download the exercises to your computer, solve them locally and then submit 
 If you want to work locally, you'll need the [`bats`][bats] program.
 Please refer to the [Testing on the Bash track][test-bash] page for the installation instructions.
 
-Your code will be tested on the Exercism jq test runner using [`jq` **version 1.7**][jq].
+Your code will be tested on the Exercism jq test runner using [`jq` version **1.8**][jq].
 
 [bats]: https://github.com/bats-core/bats-core
 [test-bash]: https://exercism.org/docs/tracks/bash/tests
-[jq]: https://jqlang.github.io/jq/manual/v1.7/
+[jq]: https://jqlang.github.io/jq/manual/v1.8/

--- a/exercises/shared/.docs/debug.md
+++ b/exercises/shared/.docs/debug.md
@@ -4,5 +4,5 @@
 Use it while you are developing your exercise solutions to inspect the data that is currently in the jq pipline.
 See the [debugging doc][debugging] for more details.
 
-[debug]: https://jqlang.github.io/jq/manual/v1.7/#debug
+[debug]: https://jqlang.github.io/jq/manual/#debug
 [debugging]: https://exercism.org/docs/tracks/jq/debugging

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -76,5 +76,5 @@ See the [debugging doc][debugging] for more details.
 [bats-assert]: https://github.com/bats-core/bats-assert
 [here-string]: https://www.gnu.org/software/bash/manual/bash.html#Here-Strings
 [so]: https://unix.stackexchange.com/a/80372/4667
-[debug]: https://jqlang.github.io/jq/manual/v1.7/#debug
+[debug]: https://jqlang.github.io/jq/manual/#debug
 [debugging]: https://exercism.org/docs/tracks/jq/debugging


### PR DESCRIPTION
## Summary

To align with #jq-test-runner/47 that updates the test runner to jq 1.8.0, let's do the same here.

Exercise tests running successfully with the new jq version on my machine.

## Checklist
- [ ] If docs where changed, run `./bin/fetch-configlet && ./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
