### PR TITLE
Create run-configlet-sync.yml

### DIFF
--- a/.github/workflows/run-configlet-sync.yml
+++ b/.github/workflows/run-configlet-sync.yml
@@ -8,3 +8,6 @@ on:
 jobs:
   call-gha-workflow:
     uses: exercism/github-actions/.github/workflows/configlet-sync.yml@main
+    with:
+      sync_docs: true
+      sync_tests: false


### PR DESCRIPTION
## Summary

Currently, the workflow is configured to run on the **15th of every month** via cron.

Let me know if you'd prefer a different schedule or trigger (e.g., weekly, 1st of each month, etc.)!


## Checklist
- [x] If docs where changed, run `./bin/fetch-configlet && ./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
