### PR TITLE
Deploy updated bats jq

### DIFF
--- a/exercises/concept/assembly-line/bats-jq.bash
+++ b/exercises/concept/assembly-line/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/concept/assembly-line/test-assembly-line.bats
+++ b/exercises/concept/assembly-line/test-assembly-line.bats
@@ -2,29 +2,6 @@
 load bats-extra
 load bats-jq
 
-assert_float() {
-    local OPTIND OPTARG
-    local decimals=2 actual expected
-    while getopts :d: opt; do
-        case $opt in
-            d) decimals=$OPTARG ;;
-            *) return 2 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
-    # bash can't do floating point: use awk (also uses IEEE754 numbers)
-    read -r actual expected < <(
-        awk -v d="$decimals" -v a="$1" -v e="$2" '
-            BEGIN {
-                m = 10 ^ d
-                print int(a * m)/m, int(e * m)/m
-            }
-        '
-    )
-    # now call a bats-assert command to get the desired output
-    assert_equal "$actual" "$expected"
-}
-
 @test production_rate_per_hour_for_speed_zero {
     ## task 1
     run jq -f assembly-line.jq <<< '{"speed": 0}'

--- a/exercises/concept/bird-count/bats-jq.bash
+++ b/exercises/concept/bird-count/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/concept/bird-count/test-bird-count.bats
+++ b/exercises/concept/bird-count/test-bird-count.bats
@@ -2,12 +2,6 @@
 load bats-extra
 load bats-jq
 
-assert_key_value() {
-    local key=$1 expected=$2 actual
-    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
-    assert_equal "$actual" "$expected"
-}
-
 @test last_week {
     ## task 1
     run jq -f bird-count.jq bird-counting-data.json

--- a/exercises/concept/grade-stats/bats-jq.bash
+++ b/exercises/concept/grade-stats/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/concept/grade-stats/test-grade-stats.bats
+++ b/exercises/concept/grade-stats/test-grade-stats.bats
@@ -2,12 +2,6 @@
 load bats-extra
 load bats-jq
 
-assert_key_value() {
-    local key=$1 expected=$2 actual
-    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
-    assert_equal "$actual" "$expected"
-}
-
 @test 'number to letter grade A' {
     ## task 1
     run jq -nc '

--- a/exercises/concept/high-score-board/bats-jq.bash
+++ b/exercises/concept/high-score-board/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/concept/high-score-board/test-high-score-board.bats
+++ b/exercises/concept/high-score-board/test-high-score-board.bats
@@ -2,12 +2,6 @@
 load bats-extra
 load bats-jq
 
-assert_key_value() {
-    local key=$1 expected=$2 actual
-    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
-    assert_equal "$actual" "$expected"
-}
-
 @test creates_a_new_board_with_a_test_entry {
     ## task 1
     run jq -n -c '

--- a/exercises/concept/lasagna/bats-jq.bash
+++ b/exercises/concept/lasagna/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/concept/lasagna/test-lasagna.bats
+++ b/exercises/concept/lasagna/test-lasagna.bats
@@ -2,17 +2,11 @@
 load bats-extra
 load bats-jq
 
-assert_key_value() {
-    local result
-    result=$(echo "$output" | jq -r --arg key "$2" --argjson val "$1" '.[$key] == $val')
-    [[ $result == "true" ]]
-}
-
 @test "Expected minutes in oven" {
     ## task 1
     run jq -f lasagna.jq --null-input
     assert_success
-    assert_key_value 40 "expected_minutes_in_oven"
+    assert_key_value "expected_minutes_in_oven" 40
 }
 
 @test "Calculate the remaining minutes in oven" {
@@ -23,14 +17,14 @@ assert_key_value() {
       }
 END_INPUT
     assert_success
-    assert_key_value 15 "remaining_minutes_in_oven"
+    assert_key_value "remaining_minutes_in_oven" 15
 }
 
 @test "Calculate the remaining minutes in oven, not yet started" {
     ## task 2
     run jq -f lasagna.jq --null-input
     assert_success
-    assert_key_value 40 "remaining_minutes_in_oven"
+    assert_key_value "remaining_minutes_in_oven" 40
 }
 
 @test "Calculate the preparation time with one layer" {
@@ -41,7 +35,7 @@ END_INPUT
       }
 END_INPUT
     assert_success
-    assert_key_value 2 "preparation_time"
+    assert_key_value "preparation_time" 2
 }
 
 @test "Calculate the preparation time with four layers" {
@@ -52,14 +46,14 @@ END_INPUT
       }
 END_INPUT
     assert_success
-    assert_key_value 8 "preparation_time"
+    assert_key_value "preparation_time" 8
 }
 
 @test "Calculate the preparation time with no layers specified (default 1)" {
     ## task 3
     run jq -f lasagna.jq --null-input
     assert_success
-    assert_key_value 2 "preparation_time"
+    assert_key_value "preparation_time" 2
 }
 
 @test "Total time elapsed with one layers" {
@@ -71,7 +65,7 @@ END_INPUT
       }
 END_INPUT
     assert_success
-    assert_key_value 32 "total_time"
+    assert_key_value "total_time" 32
 }
 
 @test "Total time elapsed with four layers" {
@@ -83,7 +77,7 @@ END_INPUT
       }
 END_INPUT
     assert_success
-    assert_key_value 18 "total_time"
+    assert_key_value "total_time" 18
 }
 
 # vim: sw=4 ts=8

--- a/exercises/concept/log-line-parser/bats-jq.bash
+++ b/exercises/concept/log-line-parser/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/concept/recursive-functions/bats-jq.bash
+++ b/exercises/concept/recursive-functions/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/concept/recursive-functions/test-recursive-functions.bats
+++ b/exercises/concept/recursive-functions/test-recursive-functions.bats
@@ -2,12 +2,6 @@
 load bats-extra
 load bats-jq
 
-assert_key_value() {
-    local result
-    result=$(echo "$output" | jq -r --arg key "$2" --argjson val "$1" '.[$key] == $val')
-    [[ $result == "true" ]]
-}
-
 @test "Sum of empty array" {
     ## task 1
     run jq -n '

--- a/exercises/concept/regular-chatbot/bats-jq.bash
+++ b/exercises/concept/regular-chatbot/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/concept/remote-control-car/bats-jq.bash
+++ b/exercises/concept/remote-control-car/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/concept/remote-control-car/test-remote-control-car.bats
+++ b/exercises/concept/remote-control-car/test-remote-control-car.bats
@@ -2,13 +2,6 @@
 load bats-extra
 load bats-jq
 
-assert_key_value() {
-    local expected=$1 key=$2
-    local result
-    result=$(echo "$output" | jq -r --arg key "$key" --argjson val "$expected" '.[$key] == $val')
-    [[ $result == "true" ]]
-}
-
 @test "new car" {
     ## task 1
     run jq -n '
@@ -16,9 +9,9 @@ assert_key_value() {
         new_remote_control_car
     '
     assert_success
-    assert_key_value 100    "battery_percentage"
-    assert_key_value 0      "distance_driven_in_meters"
-    assert_key_value "null" "nickname"
+    assert_key_value "battery_percentage" 100
+    assert_key_value "distance_driven_in_meters" 0
+    assert_key_value "nickname" "null"
 }
 
 @test "new car with nickname" {
@@ -28,9 +21,9 @@ assert_key_value() {
         new_remote_control_car("Red")
     '
     assert_success
-    assert_key_value 100     "battery_percentage"
-    assert_key_value 0       "distance_driven_in_meters"
-    assert_key_value '"Red"' "nickname"
+    assert_key_value "battery_percentage" 100
+    assert_key_value "distance_driven_in_meters" 0
+    assert_key_value "nickname" "Red"
 }
 
 @test "display distance for new car is zero" {
@@ -96,8 +89,8 @@ assert_key_value() {
         new_remote_control_car | drive
     '
     assert_success
-    assert_key_value 99 "battery_percentage"
-    assert_key_value 20 "distance_driven_in_meters"
+    assert_key_value "battery_percentage" 99
+    assert_key_value "distance_driven_in_meters" 20
 }
 
 @test "drive a car with a dead battery" {
@@ -110,8 +103,8 @@ assert_key_value() {
         | drive
     '
     assert_success
-    assert_key_value  0 "battery_percentage"
-    assert_key_value 20 "distance_driven_in_meters"
+    assert_key_value "battery_percentage"  0
+    assert_key_value "distance_driven_in_meters" 20
 }
 
 

--- a/exercises/concept/shopping/bats-jq.bash
+++ b/exercises/concept/shopping/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)

--- a/exercises/concept/vehicle-purchase/bats-jq.bash
+++ b/exercises/concept/vehicle-purchase/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/acronym/bats-jq.bash
+++ b/exercises/practice/acronym/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/all-your-base/bats-jq.bash
+++ b/exercises/practice/all-your-base/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/allergies/bats-jq.bash
+++ b/exercises/practice/allergies/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/anagram/bats-jq.bash
+++ b/exercises/practice/anagram/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/armstrong-numbers/bats-jq.bash
+++ b/exercises/practice/armstrong-numbers/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/atbash-cipher/bats-jq.bash
+++ b/exercises/practice/atbash-cipher/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/beer-song/bats-jq.bash
+++ b/exercises/practice/beer-song/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/binary-search/bats-jq.bash
+++ b/exercises/practice/binary-search/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/bob/bats-jq.bash
+++ b/exercises/practice/bob/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/bottle-song/bats-jq.bash
+++ b/exercises/practice/bottle-song/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/collatz-conjecture/bats-jq.bash
+++ b/exercises/practice/collatz-conjecture/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/darts/bats-jq.bash
+++ b/exercises/practice/darts/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/diamond/bats-jq.bash
+++ b/exercises/practice/diamond/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/difference-of-squares/bats-jq.bash
+++ b/exercises/practice/difference-of-squares/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/eliuds-eggs/bats-jq.bash
+++ b/exercises/practice/eliuds-eggs/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/etl/bats-jq.bash
+++ b/exercises/practice/etl/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/etl/test-etl.bats
+++ b/exercises/practice/etl/test-etl.bats
@@ -3,15 +3,6 @@
 load bats-extra
 load bats-jq
 
-assert_objects_equal() {
-    local result=$(
-        jq -n --argjson actual "$1" \
-              --argjson expected "$2" \
-            '$actual == $expected'
-    )
-    [[ $result == "true" ]]
-}
-
 @test 'single letter' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 

--- a/exercises/practice/flatten-array/bats-jq.bash
+++ b/exercises/practice/flatten-array/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/flower-field/bats-jq.bash
+++ b/exercises/practice/flower-field/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/food-chain/bats-jq.bash
+++ b/exercises/practice/food-chain/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/forth/bats-jq.bash
+++ b/exercises/practice/forth/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/gigasecond/bats-jq.bash
+++ b/exercises/practice/gigasecond/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/grade-school/bats-jq.bash
+++ b/exercises/practice/grade-school/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/hamming/bats-jq.bash
+++ b/exercises/practice/hamming/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/hello-world/bats-jq.bash
+++ b/exercises/practice/hello-world/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/isogram/bats-jq.bash
+++ b/exercises/practice/isogram/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/kindergarten-garden/bats-jq.bash
+++ b/exercises/practice/kindergarten-garden/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/knapsack/bats-jq.bash
+++ b/exercises/practice/knapsack/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/largest-series-product/bats-jq.bash
+++ b/exercises/practice/largest-series-product/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/leap/bats-jq.bash
+++ b/exercises/practice/leap/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/luhn/bats-jq.bash
+++ b/exercises/practice/luhn/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/matching-brackets/bats-jq.bash
+++ b/exercises/practice/matching-brackets/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/meetup/bats-jq.bash
+++ b/exercises/practice/meetup/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/minesweeper/bats-jq.bash
+++ b/exercises/practice/minesweeper/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/nth-prime/bats-jq.bash
+++ b/exercises/practice/nth-prime/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/nucleotide-count/bats-jq.bash
+++ b/exercises/practice/nucleotide-count/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/nucleotide-count/test-nucleotide-count.bats
+++ b/exercises/practice/nucleotide-count/test-nucleotide-count.bats
@@ -3,15 +3,6 @@
 load bats-extra
 load bats-jq
 
-assert_objects_equal() {
-    local result=$(
-        jq -n --argjson actual "$1" \
-              --argjson expected "$2" \
-            '$actual == $expected'
-    )
-    [[ $result == "true" ]]
-}
-
 @test 'empty strand' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 

--- a/exercises/practice/pangram/bats-jq.bash
+++ b/exercises/practice/pangram/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/pascals-triangle/bats-jq.bash
+++ b/exercises/practice/pascals-triangle/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/phone-number/bats-jq.bash
+++ b/exercises/practice/phone-number/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/pig-latin/bats-jq.bash
+++ b/exercises/practice/pig-latin/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/prime-factors/bats-jq.bash
+++ b/exercises/practice/prime-factors/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/protein-translation/bats-jq.bash
+++ b/exercises/practice/protein-translation/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/proverb/bats-jq.bash
+++ b/exercises/practice/proverb/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/raindrops/bats-jq.bash
+++ b/exercises/practice/raindrops/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/resistor-color-duo/bats-jq.bash
+++ b/exercises/practice/resistor-color-duo/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/resistor-color-trio/bats-jq.bash
+++ b/exercises/practice/resistor-color-trio/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/resistor-color/bats-jq.bash
+++ b/exercises/practice/resistor-color/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/reverse-string/bats-jq.bash
+++ b/exercises/practice/reverse-string/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/rna-transcription/bats-jq.bash
+++ b/exercises/practice/rna-transcription/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/robot-simulator/bats-jq.bash
+++ b/exercises/practice/robot-simulator/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/robot-simulator/test-robot-simulator.bats
+++ b/exercises/practice/robot-simulator/test-robot-simulator.bats
@@ -3,19 +3,6 @@
 load bats-extra
 load bats-jq
 
-assert_objects_equal() {
-    local result=$(
-        jq -n --argjson actual "$1" \
-              --argjson expected "$2" \
-            '$actual == $expected'
-    )
-    if [[ $result != "true" ]]; then
-        echo "expected: $2" >&2
-        echo "actual: $1" >&2
-        return 1
-    fi
-}
-
 @test 'Create robot:at origin facing north' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 

--- a/exercises/practice/roman-numerals/bats-jq.bash
+++ b/exercises/practice/roman-numerals/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/rotational-cipher/bats-jq.bash
+++ b/exercises/practice/rotational-cipher/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/run-length-encoding/bats-jq.bash
+++ b/exercises/practice/run-length-encoding/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/satellite/bats-jq.bash
+++ b/exercises/practice/satellite/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/satellite/test-satellite.bats
+++ b/exercises/practice/satellite/test-satellite.bats
@@ -3,15 +3,6 @@
 load bats-extra
 load bats-jq
 
-assert_objects_equal() {
-    local result=$(
-        jq -n --argjson actual "$1" \
-              --argjson expected "$2" \
-            '$actual == $expected'
-    )
-    [[ $result == "true" ]]
-}
-
 @test 'Empty tree' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 

--- a/exercises/practice/scrabble-score/bats-jq.bash
+++ b/exercises/practice/scrabble-score/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/secret-handshake/bats-jq.bash
+++ b/exercises/practice/secret-handshake/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/series/bats-jq.bash
+++ b/exercises/practice/series/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/sieve/bats-jq.bash
+++ b/exercises/practice/sieve/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/space-age/bats-jq.bash
+++ b/exercises/practice/space-age/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/spiral-matrix/bats-jq.bash
+++ b/exercises/practice/spiral-matrix/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/square-root/bats-jq.bash
+++ b/exercises/practice/square-root/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/transpose/bats-jq.bash
+++ b/exercises/practice/transpose/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/two-bucket/bats-jq.bash
+++ b/exercises/practice/two-bucket/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/two-bucket/test-two-bucket.bats
+++ b/exercises/practice/two-bucket/test-two-bucket.bats
@@ -3,15 +3,6 @@
 load bats-extra
 load bats-jq
 
-assert_objects_equal() {
-    local result=$(
-        jq -n --argjson actual "$1" \
-              --argjson expected "$2" \
-            '$actual == $expected'
-    )
-    [[ $result == "true" ]]
-}
-
 @test 'Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one' {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 

--- a/exercises/practice/two-fer/bats-jq.bash
+++ b/exercises/practice/two-fer/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/yacht/bats-jq.bash
+++ b/exercises/practice/yacht/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }

--- a/exercises/practice/zebra-puzzle/bats-jq.bash
+++ b/exercises/practice/zebra-puzzle/bats-jq.bash
@@ -10,7 +10,6 @@
 # - "Printing to the terminal", https://bats-core.readthedocs.io/en/stable/writing-tests.html#printing-to-the-terminal
 # - "File descriptor 3", https://bats-core.readthedocs.io/en/stable/writing-tests.html#file-descriptor-3-read-this-if-bats-hangs
 
-
 jq() {
     local output stderr rc line
     stderr=$(mktemp)
@@ -26,4 +25,65 @@ jq() {
     rm -f "$stderr"
     echo "$output"
     return "$rc"
+}
+
+#############################################################
+# These are extra assert functions for use in tests.
+
+# Assert two JSON objects are equal.
+#   https://jqlang.org/manual/v1.7/#==-!=
+#
+#   assert_objects_equal '{"a": 1, "b": 2}' '{"b":2,"a":1}' 
+#   # => true
+#
+assert_objects_equal() {
+    local result=$(
+        jq -n --argjson actual "$1" \
+              --argjson expected "$2" \
+            '$actual == $expected'
+    )
+    [[ $result == "true" ]]
+}
+
+# Assert 2 floating-point values are "close enough".
+#
+#   # are they the same to 2 decimal places?
+#   assert_float 1.993 1.995        # => true
+#
+#   # are they the same to 3 decimal places?
+#   assert_float -d 3 1.993 1.995   # => false
+#
+assert_float() {
+    local OPTIND OPTARG
+    local decimals=2 actual expected
+    while getopts :d: opt; do
+        case $opt in
+            d) decimals=$OPTARG ;;
+            *) return 2 ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+    # bash can't do floating point: use awk
+    read -r actual expected < <(
+        awk -v d="$decimals" -v a="$1" -v e="$2" '
+            BEGIN {
+                m = 10 ^ d
+                print int(a * m)/m, int(e * m)/m
+            }
+        '
+    )
+    # now call a bats-assert command to get the desired output
+    assert_equal "$actual" "$expected"
+}
+
+# Assert that an object's value of a given key is the expected value.
+# This uses the bats `output` variable.
+#
+#   run jq -f ...
+#   assert_key_value 'the_key' 'the_expected_value'
+#
+assert_key_value() {
+    local key=$1 expected=$2 actual
+    actual=$(jq -rc --arg key "$key" '.[$key]' <<< "$output")
+    assert_equal "$actual" "$expected"
 }


### PR DESCRIPTION
This PR contains a lot of changed files, but the changes are (almost) all boiler plate: 
* custom assert functions are removed from the test scripts and provided in a lib file, bats-jq.bash
