### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# placeholder
+# Instructions append
+
+## Implementation
 
 To solve this exercise in jq, you will need to use the [builtin datetime functions][date-funcs].
 


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.