### PR TITLE
`bats-jq.bash`: avoid command substitution inside a declare as it masks the exit status

### DIFF
--- a/exercises/concept/assembly-line/bats-jq.bash
+++ b/exercises/concept/assembly-line/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/concept/bird-count/bats-jq.bash
+++ b/exercises/concept/bird-count/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/concept/grade-stats/bats-jq.bash
+++ b/exercises/concept/grade-stats/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/concept/high-score-board/bats-jq.bash
+++ b/exercises/concept/high-score-board/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/concept/lasagna/bats-jq.bash
+++ b/exercises/concept/lasagna/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/concept/log-line-parser/bats-jq.bash
+++ b/exercises/concept/log-line-parser/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/concept/recursive-functions/bats-jq.bash
+++ b/exercises/concept/recursive-functions/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/concept/regular-chatbot/bats-jq.bash
+++ b/exercises/concept/regular-chatbot/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/concept/remote-control-car/bats-jq.bash
+++ b/exercises/concept/remote-control-car/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/concept/shopping/bats-jq.bash
+++ b/exercises/concept/shopping/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/concept/vehicle-purchase/bats-jq.bash
+++ b/exercises/concept/vehicle-purchase/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/acronym/bats-jq.bash
+++ b/exercises/practice/acronym/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/all-your-base/bats-jq.bash
+++ b/exercises/practice/all-your-base/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/allergies/bats-jq.bash
+++ b/exercises/practice/allergies/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/anagram/bats-jq.bash
+++ b/exercises/practice/anagram/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/armstrong-numbers/bats-jq.bash
+++ b/exercises/practice/armstrong-numbers/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/atbash-cipher/bats-jq.bash
+++ b/exercises/practice/atbash-cipher/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/beer-song/bats-jq.bash
+++ b/exercises/practice/beer-song/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/binary-search/bats-jq.bash
+++ b/exercises/practice/binary-search/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/bob/bats-jq.bash
+++ b/exercises/practice/bob/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/bottle-song/bats-jq.bash
+++ b/exercises/practice/bottle-song/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/collatz-conjecture/bats-jq.bash
+++ b/exercises/practice/collatz-conjecture/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/darts/bats-jq.bash
+++ b/exercises/practice/darts/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/diamond/bats-jq.bash
+++ b/exercises/practice/diamond/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/difference-of-squares/bats-jq.bash
+++ b/exercises/practice/difference-of-squares/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/eliuds-eggs/bats-jq.bash
+++ b/exercises/practice/eliuds-eggs/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/etl/bats-jq.bash
+++ b/exercises/practice/etl/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/flatten-array/bats-jq.bash
+++ b/exercises/practice/flatten-array/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/flower-field/bats-jq.bash
+++ b/exercises/practice/flower-field/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/food-chain/bats-jq.bash
+++ b/exercises/practice/food-chain/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/forth/bats-jq.bash
+++ b/exercises/practice/forth/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/gigasecond/bats-jq.bash
+++ b/exercises/practice/gigasecond/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/grade-school/bats-jq.bash
+++ b/exercises/practice/grade-school/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/hamming/bats-jq.bash
+++ b/exercises/practice/hamming/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/hello-world/bats-jq.bash
+++ b/exercises/practice/hello-world/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/isogram/bats-jq.bash
+++ b/exercises/practice/isogram/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/kindergarten-garden/bats-jq.bash
+++ b/exercises/practice/kindergarten-garden/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/knapsack/bats-jq.bash
+++ b/exercises/practice/knapsack/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/largest-series-product/bats-jq.bash
+++ b/exercises/practice/largest-series-product/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/leap/bats-jq.bash
+++ b/exercises/practice/leap/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/luhn/bats-jq.bash
+++ b/exercises/practice/luhn/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/matching-brackets/bats-jq.bash
+++ b/exercises/practice/matching-brackets/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/meetup/bats-jq.bash
+++ b/exercises/practice/meetup/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/minesweeper/bats-jq.bash
+++ b/exercises/practice/minesweeper/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/nth-prime/bats-jq.bash
+++ b/exercises/practice/nth-prime/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/nucleotide-count/bats-jq.bash
+++ b/exercises/practice/nucleotide-count/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/pangram/bats-jq.bash
+++ b/exercises/practice/pangram/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/pascals-triangle/bats-jq.bash
+++ b/exercises/practice/pascals-triangle/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/phone-number/bats-jq.bash
+++ b/exercises/practice/phone-number/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/pig-latin/bats-jq.bash
+++ b/exercises/practice/pig-latin/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/prime-factors/bats-jq.bash
+++ b/exercises/practice/prime-factors/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/protein-translation/bats-jq.bash
+++ b/exercises/practice/protein-translation/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/proverb/bats-jq.bash
+++ b/exercises/practice/proverb/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/raindrops/bats-jq.bash
+++ b/exercises/practice/raindrops/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/resistor-color-duo/bats-jq.bash
+++ b/exercises/practice/resistor-color-duo/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/resistor-color-trio/bats-jq.bash
+++ b/exercises/practice/resistor-color-trio/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/resistor-color/bats-jq.bash
+++ b/exercises/practice/resistor-color/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/reverse-string/bats-jq.bash
+++ b/exercises/practice/reverse-string/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/rna-transcription/bats-jq.bash
+++ b/exercises/practice/rna-transcription/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/robot-simulator/bats-jq.bash
+++ b/exercises/practice/robot-simulator/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/roman-numerals/bats-jq.bash
+++ b/exercises/practice/roman-numerals/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/rotational-cipher/bats-jq.bash
+++ b/exercises/practice/rotational-cipher/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/run-length-encoding/bats-jq.bash
+++ b/exercises/practice/run-length-encoding/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/satellite/bats-jq.bash
+++ b/exercises/practice/satellite/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/scrabble-score/bats-jq.bash
+++ b/exercises/practice/scrabble-score/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/secret-handshake/bats-jq.bash
+++ b/exercises/practice/secret-handshake/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/series/bats-jq.bash
+++ b/exercises/practice/series/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/sieve/bats-jq.bash
+++ b/exercises/practice/sieve/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/space-age/bats-jq.bash
+++ b/exercises/practice/space-age/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/spiral-matrix/bats-jq.bash
+++ b/exercises/practice/spiral-matrix/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/square-root/bats-jq.bash
+++ b/exercises/practice/square-root/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/tournament/bats-jq.bash
+++ b/exercises/practice/tournament/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/transpose/bats-jq.bash
+++ b/exercises/practice/transpose/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/two-bucket/bats-jq.bash
+++ b/exercises/practice/two-bucket/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/two-fer/bats-jq.bash
+++ b/exercises/practice/two-fer/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/yacht/bats-jq.bash
+++ b/exercises/practice/yacht/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/exercises/practice/zebra-puzzle/bats-jq.bash
+++ b/exercises/practice/zebra-puzzle/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'

--- a/lib/bats-jq.bash
+++ b/lib/bats-jq.bash
@@ -37,7 +37,8 @@ jq() {
 #   # => true
 #
 assert_objects_equal() {
-    local result=$(
+    local result
+    result=$(
         jq -n --argjson actual "$1" \
               --argjson expected "$2" \
             '$actual == $expected'


### PR DESCRIPTION
Issue reported by shellcheck