### PR TITLE
Fix shellcheck issues.

### DIFF
--- a/bin/generate_tests
+++ b/bin/generate_tests
@@ -212,8 +212,9 @@ END_PREAMBLE
     | tee "$testFile"
 
     if grep -q assert_objects_equal "$testFile"; then
-        local t=$(mktemp)
-        local func=$(cat <<'END_FUNC'
+        local t func
+        t=$(mktemp)
+        func=$(cat <<'END_FUNC'
 assert_objects_equal() {
     local result=$(
         jq -n --argjson actual "$1" \\

--- a/bin/pr
+++ b/bin/pr
@@ -12,7 +12,6 @@ fi
 shopt -s extglob
 
 declare -A seen=()
-declare -a dirs
 status=0
 
 for file; do

--- a/bin/validate_one_exercise
+++ b/bin/validate_one_exercise
@@ -32,6 +32,7 @@ readarray -t editor_files < <(jq -r '.files.editor[]?' "$config")
 # neither do concept exercises
 if [[ ${exercise} != "hello-world" ]] && ! [[ $PWD =~ exercises/concept/ ]]; then
     # a PCRE: the `\Q...\E` defines a literal segment
+    # shellcheck disable=SC2016 # no expansion wanted inside ''
     skip_re='^\s*#+\s*\Q[[ $BATS_RUN_SKIPPED == "true" ]] || skip\E$'
     num_skip_comments=$(grep -cP "${skip_re}" "${tests}") || :
     (( num_skip_comments == 1 )) || die "There should be exactly one commented skip directive in ${tests}"


### PR DESCRIPTION
* `SC2155 (warning): Declare and assign separately to avoid masking return values.`
* `SC2034 (warning): dirs appears unused. Verify use (or export if used externally).`
* `SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.`
