### PR TITLE
Improve the test generator

### DIFF
--- a/bin/test-generator
+++ b/bin/test-generator
@@ -28,31 +28,85 @@ def problem_spec_dir() -> pathlib.Path:
     raise LookupError("Could not find problem specs")
 
 
-def generate(specs: pathlib.Path, exercise: pathlib.Path) -> None:
-    """Generate and write test file for a given spec and exercise."""
+def flatten_cases(cases: list[dict]) -> list[tuple[list[str], dict]]:
+    """Recursive flatten test cases, returning individual cases with parent descriptions."""
+    for case_or_group in cases:
+        if "cases" in case_or_group:
+            for groups, child_case in flatten_cases(case_or_group["cases"]):
+                yield ([case_or_group["description"]] + groups, child_case)
+        else:
+            yield ([], case_or_group)
+
+
+def get_cases(specs: pathlib.Path, exercise: pathlib.Path) -> list[dict]:
+    """Return flattened, filtered cases with additional metadata attached."""
     canonical_path = specs / "exercises" / exercise.name / "canonical-data.json"
     with open(canonical_path, "r", encoding="utf-8") as f:
         canonical = json.load(f)
     with open(exercise / ".meta" / "tests.toml", "rb") as f:
         tests = tomllib.load(f)
-    # Filter out test cases with include=false.
-    cases = [
-        case
-        for case in canonical["cases"]
-        if tests.get(case["uuid"], {"include": False}).get("include", True)
-    ]
-    data = {
-        "generated": datetime.datetime.now(tz=datetime.UTC).replace(microsecond=0).isoformat(),
-	"slug": exercise.name,
-        "cases": list(enumerate(cases)),
-    }
 
-    # Configure the Jinja2 env.
+    reimplemented = {
+        test["reimplements"]
+        for test in tests.values()
+        if test.get("include", True) and "reimplements" in test
+    }
+    cases = []
+    for groups, case in flatten_cases(canonical["cases"]):
+        # Filter out test cases with include=false or not listed.
+        if case["uuid"] not in tests or case["uuid"] in reimplemented:
+            continue
+        if not tests[case["uuid"]].get("include", True):
+            continue
+        # Add metadata.
+        case["descriptions"] = groups + [case["description"]]
+        case["expect_error"] = isinstance(case["expected"], dict) and "error" in case["expected"]
+        if case["expect_error"]:
+            case["expect_error_msg"] = case["expected"]["error"]
+        cases.append(case)
+    return cases
+
+
+def jinja_env(exercise: pathlib.Path) -> jinja2.Environment:
+    """Return a configured Jinja env with filters added."""
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(exercise / ".meta"))
     env.filters["quote"] = shlex.quote
     env.filters["json_input"] = lambda x: textwrap.indent(json.dumps(x, indent=2), " " * 8)
+    env.filters["tojson"] = json.dumps
+    env.filters["format_list"] = lambda x: shlex.quote(
+        "[" + ",".join(f'"{i}"' if isinstance(i, str) else str(i) for i in x) + "]"
+    )
+    return env
+
+
+def generate(specs: pathlib.Path, exercise: pathlib.Path) -> None:
+    """Generate and write test file for a given spec and exercise."""
+    cases = get_cases(specs, exercise)
+
+    timestamp = datetime.datetime.now(tz=datetime.UTC).replace(microsecond=0).isoformat()
+    header = textwrap.dedent(f"""\
+        #!/usr/bin/env bats
+        # generated on {timestamp}
+        load bats-extra
+        load bats-jq"""
+    )
+    data = {
+        "cases": list(enumerate(cases)),
+        "header": header,
+        "slug": exercise.name,
+    }
+
     # Render the template.
-    out = env.get_template("template.j2").render(data)
+    out = jinja_env(exercise).get_template("template.j2").render(data)
+
+    # Check for changes or the lack thereof.
+    test_file = exercise / f"test-{exercise.name}.bats"
+    if test_file.exists():
+        old_content = [i for i in test_file.read_text().splitlines() if "generated on" not in i]
+        new_content = [i for i in out.splitlines() if "generated on" not in i]
+        if old_content == new_content:
+            return
+
     # Write the test file.
     (exercise / f"test-{exercise.name}.bats").write_text(out)
 

--- a/bin/test-generator
+++ b/bin/test-generator
@@ -2,6 +2,7 @@
 
 """Test generator v1."""
 
+import argparse
 import datetime
 import json
 import os
@@ -72,7 +73,7 @@ def jinja_env(exercise: pathlib.Path) -> jinja2.Environment:
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(exercise / ".meta"))
     env.filters["quote"] = shlex.quote
     env.filters["json_input"] = lambda x: textwrap.indent(json.dumps(x, indent=2), " " * 8)
-    env.filters["tojson"] = json.dumps
+    env.filters["tojson"] = lambda x: json.dumps(x, separators=(',', ':'))
     env.filters["format_list"] = lambda x: shlex.quote(
         "[" + ",".join(f'"{i}"' if isinstance(i, str) else str(i) for i in x) + "]"
     )
@@ -93,14 +94,14 @@ def generate(specs: pathlib.Path, exercise: pathlib.Path) -> None:
     data = {
         "cases": list(enumerate(cases)),
         "header": header,
-        "slug": exercise.name,
+        "solution": json.loads((exercise / ".meta/config.json").read_text())["files"]["solution"][0]
     }
 
     # Render the template.
     out = jinja_env(exercise).get_template("template.j2").render(data)
 
     # Check for changes or the lack thereof.
-    test_file = exercise / f"test-{exercise.name}.bats"
+    test_file = exercise / json.loads((exercise / ".meta/config.json").read_text())["files"]["test"][0]
     if test_file.exists():
         old_content = [i for i in test_file.read_text().splitlines() if "generated on" not in i]
         new_content = [i for i in out.splitlines() if "generated on" not in i]
@@ -108,14 +109,32 @@ def generate(specs: pathlib.Path, exercise: pathlib.Path) -> None:
             return
 
     # Write the test file.
-    (exercise / f"test-{exercise.name}.bats").write_text(out)
+    test_file.write_text(out)
+
+
+def argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--no-pull",
+        action="store_false",
+        dest="pull",
+        help="Do not run `git pull` on the problem specs repo",
+    )
+    parser.add_argument(
+        "exercises",
+        nargs="*",
+        help="exercises to generate tests; if none supplied, generate all"
+    )
+    return parser
 
 
 def main():
     """Main entrypoint."""
     specs = problem_spec_dir()
-    subprocess.check_call(["git", "pull"], cwd=specs)
-    exercises = sys.argv[1:]
+    args = argparser().parse_args()
+    if args.pull:
+        subprocess.check_call(["git", "pull"], cwd=specs)
+    exercises = args.exercises
     # Generate all exercises with templates if none are specified as args.
     if not exercises:
         exercises = [

--- a/exercises/practice/bob/.meta/template.j2
+++ b/exercises/practice/bob/.meta/template.j2
@@ -1,7 +1,4 @@
-#!/usr/bin/env bats
-# generated on {{ generated }}
-load bats-extra
-load bats-jq
+{{ header }}
 {% for idx, case in cases %}
 @test {{ case["description"] | quote }} {
     {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip

--- a/exercises/practice/bob/.meta/template.j2
+++ b/exercises/practice/bob/.meta/template.j2
@@ -3,7 +3,7 @@
 @test {{ case["description"] | quote }} {
     {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
-    run jq -r -f {{ slug }}.jq << 'END_INPUT'
+    run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | json_input }}
 END_INPUT
 


### PR DESCRIPTION
This builds on top of #307 for #197 

* Ignore test cases which are reimplemented (even if they are not explicitly set to `include=False`)
* Add a "group" tag for grouped test cases
* Move the common header to a variable
* Override the `tojson` filter
* Do not replace test files when the only change is the "generated on" line
