### PR TITLE
Remove the index from the test case loop; simplify the cases object

### DIFF
--- a/bin/test-generator
+++ b/bin/test-generator
@@ -101,7 +101,7 @@ def generate(specs: pathlib.Path, exercise: pathlib.Path) -> None:
         load bats-jq"""
     )
     data = {
-        "cases": list(enumerate(cases)),
+        "cases": cases,
         "header": header,
         "solution": json.loads((exercise / ".meta/config.json").read_text())["files"]["solution"][0]
     }

--- a/exercises/practice/acronym/.meta/template.j2
+++ b/exercises/practice/acronym/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["description"] | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/all-your-base/.meta/template.j2
+++ b/exercises/practice/all-your-base/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["description"] | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/allergies/.meta/template.j2
+++ b/exercises/practice/allergies/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["descriptions"] | join(":") | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq {% if case["property"] == "list" %}-c{% else %}-r{% endif %} -f {{ solution }} << 'END_INPUT'
 {{ case | filter_keys("property", "input") | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/anagram/.meta/template.j2
+++ b/exercises/practice/anagram/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["description"] | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/armstrong-numbers/.meta/template.j2
+++ b/exercises/practice/armstrong-numbers/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["description"] | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/atbash-cipher/.meta/template.j2
+++ b/exercises/practice/atbash-cipher/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["descriptions"] | join(":") | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq {% if case["property"] == "list" %}-c{% else %}-r{% endif %} -f {{ solution }} << 'END_INPUT'
 {{ case | filter_keys("property", "input") | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/binary-search/.meta/template.j2
+++ b/exercises/practice/binary-search/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["description"] | quote | replace('"\'"', "\\'") }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq {% if case["expect_error"] %}-c{% else %}-r{% endif %} -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/bob/.meta/template.j2
+++ b/exercises/practice/bob/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["description"] | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/bottle-song/.meta/template.j2
+++ b/exercises/practice/bottle-song/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["descriptions"] | join(":") | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/collatz-conjecture/.meta/template.j2
+++ b/exercises/practice/collatz-conjecture/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["description"] | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r 'import "./collatz-conjecture" as Collatz; .number | Collatz::steps' << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/darts/.meta/template.j2
+++ b/exercises/practice/darts/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["description"] | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/diamond/.meta/template.j2
+++ b/exercises/practice/diamond/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/difference-of-squares/.meta/template.j2
+++ b/exercises/practice/difference-of-squares/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["descriptions"] | join(":") | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case | filter_keys("property", "input") | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/eliuds-eggs/.meta/template.j2
+++ b/exercises/practice/eliuds-eggs/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["description"] | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/etl/.meta/template.j2
+++ b/exercises/practice/etl/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["description"] | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/flatten-array/.meta/template.j2
+++ b/exercises/practice/flatten-array/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/flower-field/.meta/template.j2
+++ b/exercises/practice/flower-field/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -s -R -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"]["garden"] | join("\n") | replace(" ", ".") }}

--- a/exercises/practice/food-chain/.meta/template.j2
+++ b/exercises/practice/food-chain/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/forth/.meta/template.j2
+++ b/exercises/practice/forth/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["descriptions"] | join(":") }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/gigasecond/.meta/template.j2
+++ b/exercises/practice/gigasecond/.meta/template.j2
@@ -2,9 +2,9 @@
 
 # Ensure date calculations are done using UTC time zone
 export TZ=UTC
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run jq -r -f {{ solution }} <<< {{ case["input"] | tojson(separators=None) | quote }}
 
   assert_success

--- a/exercises/practice/grade-school/.meta/template.j2
+++ b/exercises/practice/grade-school/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case | filter_keys("property", "input") | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/hamming/.meta/template.j2
+++ b/exercises/practice/hamming/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/hello-world/.meta/template.j2
+++ b/exercises/practice/hello-world/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/isogram/.meta/template.j2
+++ b/exercises/practice/isogram/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/kindergarten-garden/.meta/template.j2
+++ b/exercises/practice/kindergarten-garden/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["descriptions"] | join(":") }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/knapsack/.meta/template.j2
+++ b/exercises/practice/knapsack/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/largest-series-product/.meta/template.j2
+++ b/exercises/practice/largest-series-product/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {% if case["expect_error"] %}
     run jq -c -f {{ solution }} << 'END_INPUT'
 {%- else %}

--- a/exercises/practice/leap/.meta/template.j2
+++ b/exercises/practice/leap/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/luhn/.meta/template.j2
+++ b/exercises/practice/luhn/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} <<< '"{{ case["input"]["value"] }}"'
 

--- a/exercises/practice/matching-brackets/.meta/template.j2
+++ b/exercises/practice/matching-brackets/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/meetup/.meta/template.j2
+++ b/exercises/practice/meetup/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/minesweeper/.meta/template.j2
+++ b/exercises/practice/minesweeper/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {% if case["input"]["minefield"] | length == 0 %}
     run jq -s -R -c -f {{ solution }} < /dev/null
 {%- else %}

--- a/exercises/practice/nth-prime/.meta/template.j2
+++ b/exercises/practice/nth-prime/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -n -r -f {{ solution }} --argjson n {{ case["input"]["number"] }}
 {% if case["expect_error"] %}

--- a/exercises/practice/nucleotide-count/.meta/template.j2
+++ b/exercises/practice/nucleotide-count/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/pangram/.meta/template.j2
+++ b/exercises/practice/pangram/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/pascals-triangle/.meta/template.j2
+++ b/exercises/practice/pascals-triangle/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/phone-number/.meta/template.j2
+++ b/exercises/practice/phone-number/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {% if case["expect_error"] %}
     run jq -c -f {{ solution }} << 'END_INPUT'
 {%- else %}

--- a/exercises/practice/pig-latin/.meta/template.j2
+++ b/exercises/practice/pig-latin/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["descriptions"] | join(":") }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/prime-factors/.meta/template.j2
+++ b/exercises/practice/prime-factors/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/protein-translation/.meta/template.j2
+++ b/exercises/practice/protein-translation/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/proverb/.meta/template.j2
+++ b/exercises/practice/proverb/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/raindrops/.meta/template.j2
+++ b/exercises/practice/raindrops/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/resistor-color-duo/.meta/template.j2
+++ b/exercises/practice/resistor-color-duo/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/resistor-color-trio/.meta/template.j2
+++ b/exercises/practice/resistor-color-trio/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/resistor-color/.meta/template.j2
+++ b/exercises/practice/resistor-color/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["descriptions"] | join(":") }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case | filter_keys("property", "input") | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/reverse-string/.meta/template.j2
+++ b/exercises/practice/reverse-string/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
         {

--- a/exercises/practice/rna-transcription/.meta/template.j2
+++ b/exercises/practice/rna-transcription/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r 'include "./rna-transcription"; .dna | toRna' << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/robot-simulator/.meta/template.j2
+++ b/exercises/practice/robot-simulator/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["descriptions"] | join(":") }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {%- if "instructions" in case["input"] %}

--- a/exercises/practice/roman-numerals/.meta/template.j2
+++ b/exercises/practice/roman-numerals/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run jq -r -f {{ solution }} <<< {{ case["input"] | tojson(separators=(", ", ": ")) | quote }}
     assert_success
     expected='{{ case["expected"] }}'

--- a/exercises/practice/rotational-cipher/.meta/template.j2
+++ b/exercises/practice/rotational-cipher/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/run-length-encoding/.meta/template.j2
+++ b/exercises/practice/run-length-encoding/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["descriptions"] | join(":") }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r '
                 include "./run-length-encoding";

--- a/exercises/practice/satellite/.meta/template.j2
+++ b/exercises/practice/satellite/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/scrabble-score/.meta/template.j2
+++ b/exercises/practice/scrabble-score/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/secret-handshake/.meta/template.j2
+++ b/exercises/practice/secret-handshake/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/series/.meta/template.j2
+++ b/exercises/practice/series/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/sieve/.meta/template.j2
+++ b/exercises/practice/sieve/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/space-age/.meta/template.j2
+++ b/exercises/practice/space-age/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/spiral-matrix/.meta/template.j2
+++ b/exercises/practice/spiral-matrix/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/square-root/.meta/template.j2
+++ b/exercises/practice/square-root/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/tournament/.meta/template.j2
+++ b/exercises/practice/tournament/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ {"matches": case["input"]["rows"]} | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/transpose/.meta/template.j2
+++ b/exercises/practice/transpose/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/two-bucket/.meta/template.j2
+++ b/exercises/practice/two-bucket/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -c -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/two-fer/.meta/template.j2
+++ b/exercises/practice/two-fer/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/yacht/.meta/template.j2
+++ b/exercises/practice/yacht/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case["input"] | tojson(separators=None, indent=2) | indent(8, first=True) }}

--- a/exercises/practice/zebra-puzzle/.meta/template.j2
+++ b/exercises/practice/zebra-puzzle/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     run jq -r -f {{ solution }} << 'END_INPUT'
 {{ case | filter_keys("property") | tojson(separators=None, indent=2) | indent(8, first=True) }}


### PR DESCRIPTION
Summarized changes:
```
» g diff | grep '^[+-][^+-]' | sort | uniq -c
      1 +        "cases": cases,
      1 -        "cases": list(enumerate(cases)),
     65 +{% for case in cases %}
     65 -{% for idx, case in cases %}
     64 -    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
      1 -  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     64 +    {% if not loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
      1 +  {% if not loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
```
